### PR TITLE
feat(api): versioned admin + storefront APIs and generic response env…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+A Point-of-Sale (POS) / ERP backend for a multi-branch retail business, written in Go with the Fiber v2 web framework and MongoDB. A separate Python (FastAPI) service in `invoce-generator/` parses supplier proposal/invoice documents and is reached through the Go server's forward proxy.
+
+## Commands
+
+```bash
+# Run the server (loads config.local.yaml by default — see Configuration)
+go run cmd/main.go            # cmd/main.go is the real entrypoint; root main.go is a stale stub
+
+# Build
+go build -o bin/pos-erp cmd/main.go
+goreleaser build --snapshot --clean   # cross-platform snapshot
+
+# Tests — see "Testing" below; they need a running MongoDB replica set
+go test ./test                                   # all tests
+DISABLE_LOGGING=true go test ./test              # quiet
+go test ./test -run TestCreateBranches           # a single test
+
+# Regenerate Swagger docs after changing handler annotations (run from repo root)
+swag init -g cmd/main.go      # NOTE: the older `--dir pkg,routes,app` flags are stale — `routes` is pkg/routes
+```
+
+There is no Makefile or lint config; use standard `go vet ./...` / `gofmt`.
+
+## Architecture
+
+Request flow: `cmd/main.go` → `pkg/app.New()` (builds `App` with logger, Mongo client, Fiber router, config) → `App.Run()` → `NewControllers(db)` → `SetupRoutes(router, controllers)` → `router.Listen(server.port)`.
+
+- **`pkg/app/`** — wiring only. `app.go` builds the Fiber app, OTel tracer, CORS, BasicAuth-protected `/docs` Swagger. `controllers.go` holds the `Controllers` struct, `NewControllers` (constructs every controller from one `*mongo.Database`), and `SetupRoutes`.
+- **`pkg/controllers/<domain>/`** — one package per staff domain (auth, customers/bnpl, finance, journals, products, sales, suppliers, transactions, arrivals, analytics, proxy). Each has a `New(db *mongo.Database)` constructor that grabs the Mongo collections it needs (and creates indexes inline), plus Fiber handlers with `swag` doc-comments. **Storefront** controllers live under `pkg/controllers/store/<domain>/` (auth, account, catalog, products, cart, wishlist, orders, reviews, promotions), aggregated by `pkg/controllers/store/store.go` into a `store.Controllers`.
+- **`pkg/routes/routes.go`** + **`pkg/routes/store.go`** — pure route tables: one `XxxRoutes(router, controller, middleware)` function per domain, called from `SetupRoutes`. Routes are where middleware (auth, `ShiftIsOpenMiddleware`) is attached.
+- **`pkg/repository/`** — all Mongo models / DTOs (package `models`), shared across controllers. No ORM; collections are accessed directly. The standard response envelope is the **generic** `Output[T]` (`output.go`): `NewOutput(data)` infers `T` and yields `{ "data": <T>, "error": [] }`. Error/no-data responses use `NewErrorOutput(...)` and the concrete `ErrorOutput` type; `responses.go` also defines `MessageResponse` and `TokenResponse`. **All handlers render via these helpers.** Swaggo docs them as `models.Output[Type]` (`@Success`) and `models.ErrorOutput` (`@Failure`) — no bare `Output[any]`.
+- **`pkg/middleware/`** — `auth.go`: `AuthMiddleware` (staff — loads `users` by PASETO subject into `c.Locals("user")`) and `CustomerAuthMiddleware` (storefront — loads `store_customers` into `c.Locals("customer")`). `activitiy.go` audit-logs `Activity` records with typed `ActivityType` constants after successful mutations.
+- **`platform/`** — infrastructure: `database/` (Mongo connect + transaction helpers), `logger/` (zerolog setup + Fiber middleware), `s3/` (product/proposal image storage), `cache/` (Redis, mostly unused).
+
+### API surface & auth
+
+Two route trees, both under `/api` (so both share the staff-guard prefix unless registered before it):
+
+- **Admin/staff API — `/api/v1/admin/*`** (auth/activities, suppliers, products, journals, finance, transactions, customers, bnpl, proposals). Protected by **PASETO** validating against the `users` collection (`AuthMiddleware`).
+- **Storefront API — `/api/v1/store/*`** (auth, account, catalog, products, cart, wishlist, orders, reviews, promotions). A **public** browse surface (catalog/products/promotions read + customer register/login) plus a **protected** customer surface (cart/wishlist/orders/profile/write-reviews) guarded by **`CustomerAuthMiddleware`** validating against the `store_customers` collection.
+- **Sales** remains at `/api/sales/transactions/*` (not yet moved under `/api/v1/admin`).
+
+**Two PASETO guards on overlapping `/api` prefixes, resolved by Fiber registration order** (`SetupRoutes` in `pkg/app/controllers.go`): a route registered *before* a `Group(prefix, mw)` call does **not** inherit `mw`. The registration order is therefore deliberate:
+1. `routes.PublicAuthRoutes` → `POST /api/v1/admin/auth/login` (public; **register is intentionally disabled**).
+2. `routes.StorePublicRoutes` → public store routes (no token).
+3. `app.Group("/api/v1/store", customerPaseto)` → `routes.StoreProtectedRoutes` (customer-guarded).
+4. `app.Group("/api", staffPaseto)` → all admin route registrations (store + the two logins are already registered, so the staff guard never sees them).
+
+Both guards share the decoded symmetric key. **The key must be Base64-encoded 32 bytes** (`openssl rand -base64 32`), decoded at startup; a bad/short key is fatal. ⚠️ The committed `config.local.yaml` key decodes to only **24 bytes** — to boot locally, override `SERVER_SECRET_SYMMETRIC_KEY` with a valid key.
+
+**BasicAuth** protects `/docs/*` and `/dashboard/*`, using the two `server.admin_docs_users`.
+
+### Storefront (Phase 1 — stubs)
+
+The `/api/v1/store` controllers are currently compiling **stubs** that return `models.NotImplemented` (HTTP 501): routes, the customer-auth guard, and the `store_customers` collection are wired, but business logic and most data models are not yet built. `docs/storefront-implementation-guide.md` defines the Phase-2 pattern — models in `pkg/models`, repositories under `pkg/repository/store/<domain>/` (handlers call repository methods, never the DB directly), held as a field on each controller.
+
+### Journals, shifts, and finance (core domain)
+
+The accounting heart of the system. A **journal** (`pkg/repository/journal.go`) is a per-branch daily shift containing **operations** (transactions). Key invariant: operations can only be added/edited/deleted while the shift is open — enforced by `operations.ShiftIsOpenMiddleware` (checks `Shift_is_closed`), wired in `JournalsRoutes`. Mutations that touch multiple collections (journal close/reopen, operation create/update/delete) run inside MongoDB multi-document transactions via `database.StartTransaction(client)` → `ses.CommitTransaction(ctx)` (see `pkg/controllers/journals/operations.go`). **MongoDB must be a replica set** for these transactions to work. Journal/operation activity also rolls up into branch `finance` balances and the `transactions` collection.
+
+### Proxy to the invoice service
+
+`config.server.proxy[0]` defines a forward proxy (default path `/proposals` → `http://localhost:11000`). `ProxyRoutes` PASETO-protects the proxy path and forwards requests (adding the configured `x-api-key`) to the Python `invoce-generator` FastAPI service, which parses uploaded proposal documents and generates PDFs.
+
+## Configuration
+
+Config loading (`pkg/configs/configs.go`, via Viper):
+- `ENVIRONMENT=production` → reads `config.yaml`; otherwise `config.local.yaml` (or `$CONFIG_FILE`, e.g. `CONFIG_FILE=config.staging`).
+- If `LOAD_DOT_ENV` is non-empty, `.env` is loaded.
+- Explicit env bindings override YAML — see the `bindings` map in `configs.go` (`DATABASE_*`, `REDIS_*`, `SERVER_*`, `S3_*`). Viper's automatic-env replaces `.` with `_`.
+- `LoadConfig(".")` is called repeatedly from many places (app, routes, middleware) rather than passed around — it re-reads each time, so config files must be resolvable from the working directory (it also searches `../` and `../../`, which is how tests find it).
+
+Copy `example.config.yaml` → `config.local.yaml` to start.
+
+## Testing
+
+Tests live in `test/` (package `test`) and are **integration tests against a live server + real MongoDB**, not unit tests:
+- `TestMain` (in `test/finance-branches_test.go`) calls `app.New()`, wipes the `magazin` collections (finance, suppliers, transactions, journals), then `go app.Run()` to start the server in-process, then `m.Run()`.
+- Tests drive the server over HTTP through the typed client in `test/client/` (`client.NewClient(host, port, user, pass)`), hitting `localhost` + `server.port` from `config.local.yaml`.
+- Therefore a MongoDB replica set matching `config.local.yaml` must be reachable before running `go test ./test`. `test/mock/` holds seed JSON (finances, suppliers).
+- Tests share global state (the wiped DB + running server) and are order-sensitive; `TestCreateBranches` seeds branches that later tests rely on.
+
+## Deployment
+
+`deploy/docker-compose.yml` builds `build/Dockerfile` and runs the backend behind Caddy (labels for `api.g4h.uz`), mounting `config.yaml` and `tmp/`, with `ENVIRONMENT=PRODUCTION`. External Docker networks `mongoCluster` and `caddy` must exist first. Releases are tag-driven (`v*`) via GitHub Actions + GoReleaser.
+
+## Gotchas
+
+- Root `main.go` is a leftover Petstore stub — the real entrypoint is `cmd/main.go`.
+- Many handlers return HTTP 500 (`StatusInternalServerError`) for business/validation errors (e.g. duplicate branch), not 4xx; tests assert on this.
+- `AdminDocsUsers` is indexed `[0]` and `[1]` directly — config must define at least two `admin_docs_users` or startup/route setup panics.
+- Sales *session* routes (`/api/sales/session/*`) are commented out; only `/api/sales/transactions/*` is active.
+- `config.local.yaml`'s `secret_symmetric_key` decodes to 24 bytes but PASETO needs 32 — local boot panics unless you override `SERVER_SECRET_SYMMETRIC_KEY` (and missing PASETO token → HTTP **400** `missing PASETO token`, not 401).
+- `Output` is generic (`Output[T]`); never write `NewOutput(nil, ...)` (untyped nil breaks inference) — use `NewErrorOutput(...)`. Swaggo `@Success`/`@Failure` must use a concrete type (`models.Output[Type]` / `models.ErrorOutput`), never `models.Output[any]`.
+- A few files don't import the `models` package (e.g. `product-images.go`), so their swaggo can't reference `models.*` types — they use native types (`{file} binary`, `map[string]string`).
+- Pre-existing gofmt drift in `pkg/controllers/proxy/proxy.go` and `pkg/repository/product-models.go` (unformatted at HEAD) — leave unless intentionally tidying.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,18 @@
 [![Go Version](https://img.shields.io/github/go-mod/go-version/aslon1213/g4h_pos_erp?style=flat-square)](https://golang.org/)
 [![License](https://img.shields.io/github/license/aslon1213/g4h_pos_erp?style=flat-square)](LICENSE)
 
-A modern Point of Sale (POS) and Enterprise Resource Planning (ERP) system built with Go, designed for retail businesses and stores.
+A Point of Sale (POS) and ERP backend built with Go for retail operations.
+
+## Latest Changes (May 2026)
+
+- All staff endpoints moved under a versioned **`/api/v1/admin/*`** namespace (auth, suppliers, products, journals, finance, transactions, customers, bnpl, proposals). Admin `login` stays public; `register` is disabled.
+- Added a public **storefront API** under **`/api/v1/store/*`** (customer auth, catalog, products, cart, wishlist, orders, reviews, promotions) with a dedicated `CustomerAuthMiddleware` (validates the `store_customers` collection). Phase-1 stubs — see `docs/storefront-implementation-guide.md`.
+- Response envelope is now the **generic `Output[T]`**; error responses use `ErrorOutput`. Swaggo annotations are typed per endpoint.
+
+Earlier:
+
+- Auth token handling decodes `server.secret_symmetric_key` from Base64 before creating/verifying PASETO tokens.
+- Config loading supports explicit environment variable bindings (via Viper) with optional `.env` loading using `LOAD_DOT_ENV`.
 
 ## 🚀 Features
 
@@ -27,10 +38,10 @@ A modern Point of Sale (POS) and Enterprise Resource Planning (ERP) system built
 - **Database**: MongoDB
 - **Cache**: Redis
 - **Documentation**: Swagger/OpenAPI
-- **Authentication**: JWT/BasicAuth
+- **Authentication**: PASETO (Bearer token) + BasicAuth (docs/dashboard)
 - **Observability**: OpenTelemetry
 - **Logging**: Zerolog
-- **Configuration**: Viper (YAML-based)
+- **Configuration**: Viper (YAML + environment overrides)
 
 ## 📋 Prerequisites
 
@@ -53,8 +64,8 @@ A modern Point of Sale (POS) and Enterprise Resource Planning (ERP) system built
 2. **Prepare configuration**
 
    ```bash
-   cp example.config.yaml config.yaml
-   # Edit config.yaml to match your MongoDB/Redis/S3 settings
+   cp example.config.yaml config.local.yaml
+   # Edit config.local.yaml to match your MongoDB/Redis/S3/settings
    ```
 
 3. **Create required docker networks (first run only)**
@@ -90,13 +101,13 @@ A modern Point of Sale (POS) and Enterprise Resource Planning (ERP) system built
 
 2. **Setup MongoDB**
 
-   - Use an existing MongoDB replica set, or update `config.yaml` to point to your MongoDB URL. Ensure `replica_set` aligns with your cluster if replication is enabled.
+   - Use an existing MongoDB replica set, or update your active config file (`config.local.yaml` by default, `config.yaml` in production) to point to your MongoDB URL. Ensure `replica_set` aligns with your cluster if replication is enabled.
 
 3. **Configure the application**
 
    ```bash
-   cp example.config.yaml config.yaml
-   # Edit config.yaml with your database and Redis settings
+   cp example.config.yaml config.local.yaml
+   # Edit config.local.yaml with your database and Redis settings
    ```
 
 4. **Run the application**
@@ -106,7 +117,20 @@ A modern Point of Sale (POS) and Enterprise Resource Planning (ERP) system built
 
 ## ⚙️ Configuration
 
-The application uses YAML configuration. Copy `example.config.yaml` to `config.yaml` and modify as needed:
+The app loads config in this order:
+
+- If `ENVIRONMENT=production`: uses `config.yaml`
+- Otherwise: uses `config.local.yaml` (or `CONFIG_FILE` if set, e.g. `CONFIG_FILE=config.staging`)
+- If `LOAD_DOT_ENV` is set (non-empty), `.env` is loaded
+- Bound environment variables override matching YAML keys
+
+Start from:
+
+```bash
+cp example.config.yaml config.local.yaml
+```
+
+YAML shape:
 
 ```yaml
 database:
@@ -131,26 +155,61 @@ server:
   port: ":12000"
 ```
 
+### Environment Variables (Supported Bindings)
+
+The config loader binds these env vars:
+
+- Database: `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`, `DATABASE_NAME`, `DATABASE_MAX_CONNECTIONS`, `DATABASE_MIN_POOL_SIZE`, `DATABASE_AUTH`, `DATABASE_REPLICA_SET`, `DATABASE_URL`
+- Redis: `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DATABASE`
+- Server: `SERVER_HOST`, `SERVER_PORT`, `SERVER_SECRET_SYMMETRIC_KEY`, `SERVER_TOKEN_EXPIRY_HOURS`
+- S3: `S3_REGION`, `S3_ENDPOINT`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_IMAGE_BUCKET`
+
+### Auth Key Requirement
+
+`server.secret_symmetric_key` is Base64-decoded at runtime for PASETO middleware and token creation. Use a Base64-encoded 32-byte key, for example:
+
+```bash
+openssl rand -base64 32
+```
+
 ## 📖 API Documentation
 
-Once the application is running, access the Swagger documentation at:
+Once the application is running, access Swagger at:
 
 ```
 http://localhost:12000/docs/index.html
 ```
 
-Note: Access to `/docs` is protected with BasicAuth. Default credentials are configured in `config.yaml` under `server.admin_docs_users`.
+Note: Access to `/docs` is protected with BasicAuth. Credentials are configured in `server.admin_docs_users` in your active config file.
 
-The API provides endpoints for:
+The API is split into an **admin/staff** tree and a public **storefront** tree.
 
-- `/sales` - Sales transactions
-- `/products` - Product management
-- `/customers` - Customer management
-- `/suppliers` - Supplier management
-- `/transactions` - Financial transactions
-- `/journals` - Journal entries
-- `/expenses` - Internal expenses
-- `/finance` - Financial operations
+**Admin / staff — `/api/v1/admin/*`** (PASETO bearer token against the `users` collection):
+
+- `/api/v1/admin/auth/login` (public), `/api/v1/admin/auth/me`, `/api/v1/admin/activities/*`
+- `/api/v1/admin/products/*` - product catalog, stock ops, images
+- `/api/v1/admin/customers/*` - customers
+- `/api/v1/admin/suppliers/*` - suppliers and supplier transactions
+- `/api/v1/admin/transactions/*` - transaction queries/updates/docs enums
+- `/api/v1/admin/finance/*` - branch finance
+- `/api/v1/admin/journals/*` - journal lifecycle and operations
+- `/api/v1/admin/bnpl/*`, `/api/v1/admin/branches/:branch_id/bnpls`, `/api/v1/admin/customers/:customer_id/bnpls`
+- `/api/v1/admin/proposals/*` and `/proposals` (proxy route)
+
+**Storefront — `/api/v1/store/*`** (public browse + customer PASETO token against `store_customers`):
+
+- `/api/v1/store/auth/*` (register/login public; me/logout protected), `/api/v1/store/account/addresses/*`
+- `/api/v1/store/catalog/*`, `/api/v1/store/products/*` - public catalog & product browse + reviews
+- `/api/v1/store/cart/*`, `/api/v1/store/wishlist/*`, `/api/v1/store/orders/*`, `/api/v1/store/checkout/*` - customer-only
+- `/api/v1/store/reviews/*`, `/api/v1/store/promotions/*`
+
+**Still under `/api`:** `/api/sales/transactions/*`.
+
+Notes:
+
+- Storefront endpoints are **Phase-1 stubs** (return HTTP 501 `not implemented`); routing and customer auth are wired, business logic is pending. See `docs/storefront-implementation-guide.md`.
+- The admin `register` endpoint and `/api/sales/session/*` are disabled/commented out.
+- Responses use a generic envelope `Output[T]` → `{ "data": <T>, "error": [] }`; errors use `ErrorOutput`.
 
 ## 🔧 Development
 
@@ -162,16 +221,17 @@ The API provides endpoints for:
 ├── pkg/                            # Application packages
 │   ├── app/                        # Main application logic
 │   ├── controllers/                # Business logic controllers
-│   │   ├── customers/              # Customer management
+│   │   ├── customers/              # Customer management (+ bnpl/)
 │   │   ├── finance/                # Financial operations
 │   │   ├── internalExpenses/       # Internal expenses
 │   │   ├── journals/               # Journal entries for daily financial operations
 │   │   ├── products/               # Product management
 │   │   ├── sales/                  # Sales transactions
 │   │   ├── suppliers/              # Supplier management
-│   │   └── transactions/           # Financial transactions
-│   ├── routes/                     # API route definitions
-│   ├── middleware/                 # HTTP middleware
+│   │   ├── transactions/           # Financial transactions
+│   │   └── store/                  # Storefront API (auth, cart, catalog, orders, ...)
+│   ├── routes/                     # API route definitions (routes.go, store.go)
+│   ├── middleware/                 # HTTP middleware (staff + customer auth)
 │   ├── repository/                 # Data access layer, models
 │   ├── utils/                      # Utility functions
 │   └── configs/                    # Configuration management
@@ -201,7 +261,8 @@ go test ./test
 ### Generate Swagger Documentation
 
 ```bash
-swag init -g app/app.go --dir pkg
+# Run from the repo root (the older --dir pkg,routes,app flags are stale)
+swag init -g cmd/main.go
 ```
 
 ## 🐳 Docker Deployment

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -24,7 +24,108 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/api/activities/me": {
+        "/api/sales/transactions/{branch_id}": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new sales transaction for a branch",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sales/transactions"
+                ],
+                "summary": "Create a new sales transaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Branch ID",
+                        "name": "branch_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Transaction details",
+                        "name": "transaction",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TransactionBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Output-models_Transaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/sales/transactions/{transaction_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a sales transaction by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sales/transactions"
+                ],
+                "summary": "Delete a sales transaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Transaction ID",
+                        "name": "transaction_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Output-models_Transaction"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/activities/me": {
             "get": {
                 "security": [
                     {
@@ -32,9 +133,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get the 25 most recent activities for the authenticated user",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -46,19 +144,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_middleware_Activity"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/activities/recent": {
+        "/api/v1/admin/activities/recent": {
             "get": {
                 "security": [
                     {
@@ -66,9 +164,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get the 25 most recent activities across all users",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -80,19 +175,65 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_middleware_Activity"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/auth/me": {
+        "/api/v1/admin/auth/login": {
+            "post": {
+                "description": "Authenticate user and return a token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Login a user",
+                "parameters": [
+                    {
+                        "description": "User credentials",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/auth.LoginInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "token",
+                        "schema": {
+                            "$ref": "#/definitions/models.TokenResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/auth/me": {
             "get": {
                 "security": [
                     {
@@ -100,9 +241,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get user info",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -114,22 +252,19 @@ const docTemplate = `{
                     "200": {
                         "description": "message",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/bnpl": {
+        "/api/v1/admin/bnpl": {
             "post": {
                 "security": [
                     {
@@ -162,25 +297,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_BNPL"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/bnpl/{id}": {
+        "/api/v1/admin/bnpl/{id}": {
             "get": {
                 "security": [
                     {
@@ -188,9 +323,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get details of a specific BNPL transaction",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -211,13 +343,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_BNPL"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -229,9 +361,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Delete an existing BNPL transaction",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -252,22 +381,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/bnpl/{id}/credit": {
+        "/api/v1/admin/bnpl/{id}/credit": {
             "post": {
                 "security": [
                     {
@@ -312,19 +438,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.BNPL"
+                            "$ref": "#/definitions/models.Output-array_models_BNPL"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/branches/{branch_id}/bnpls": {
+        "/api/v1/admin/branches/{branch_id}/bnpls": {
             "get": {
                 "security": [
                     {
@@ -332,9 +458,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get all BNPL transactions for a specific branch",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -373,19 +496,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Customer"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/customers": {
+        "/api/v1/admin/customers": {
             "get": {
                 "security": [
                     {
@@ -445,13 +568,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.CustomerQueryOutput"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -488,25 +617,31 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Customer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/customers/{customer_id}/bnpls": {
+        "/api/v1/admin/customers/{customer_id}/bnpls": {
             "get": {
                 "security": [
                     {
@@ -514,9 +649,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get all BNPL transactions for a specific customer",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -543,19 +675,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_BNPL"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/customers/{id}": {
+        "/api/v1/admin/customers/{id}": {
             "get": {
                 "security": [
                     {
@@ -563,9 +695,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get a customer by its ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -586,19 +715,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Customer"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -642,25 +771,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Customer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -672,9 +807,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Delete a customer from the database",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -695,25 +827,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.MessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/finance": {
+        "/api/v1/admin/finance": {
             "post": {
                 "security": [
                     {
@@ -746,25 +884,25 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_BranchFinance"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/finance/branch/id/{id}": {
+        "/api/v1/admin/finance/branch/id/{id}": {
             "get": {
                 "security": [
                     {
@@ -792,19 +930,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_BranchFinance"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/finance/branch/name/{branch_name}": {
+        "/api/v1/admin/finance/branch/name/{branch_name}": {
             "get": {
                 "security": [
                     {
@@ -832,19 +970,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_BranchFinance"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/finance/branches": {
+        "/api/v1/admin/finance/branches": {
             "get": {
                 "security": [
                     {
@@ -863,19 +1001,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_BranchFinance"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/finance/id/{id}": {
+        "/api/v1/admin/finance/id/{id}": {
             "get": {
                 "security": [
                     {
@@ -903,19 +1041,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_BranchFinance"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals": {
+        "/api/v1/admin/journals": {
             "post": {
                 "security": [
                     {
@@ -948,25 +1092,25 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Journal"
+                            "$ref": "#/definitions/models.Output-models_JournalWithTransactionID"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/branch/{branch_id}": {
+        "/api/v1/admin/journals/branch/{branch_id}": {
             "get": {
                 "security": [
                     {
@@ -974,9 +1118,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Query journal entries by branch ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1009,22 +1150,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/models.Journal"
-                            }
+                            "$ref": "#/definitions/models.Output-array_models_Journal"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/report": {
+        "/api/v1/admin/journals/report": {
             "get": {
                 "security": [
                     {
@@ -1032,9 +1176,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get a report of journal entries",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1042,10 +1183,23 @@ const docTemplate = `{
                     "journals"
                 ],
                 "summary": "Get a report",
-                "responses": {}
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.MessageResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
             }
         },
-        "/api/journals/{journal_id}": {
+        "/api/v1/admin/journals/{journal_id}": {
             "get": {
                 "security": [
                     {
@@ -1053,9 +1207,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get a journal entry by its ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1076,19 +1227,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Journal"
+                            "$ref": "#/definitions/models.Output-models_Journal"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/{journal_id}/close": {
+        "/api/v1/admin/journals/{journal_id}/close": {
             "post": {
                 "security": [
                     {
@@ -1125,31 +1276,28 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "201": {
-                        "description": "Created",
+                    "200": {
+                        "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/models.Transaction"
-                            }
+                            "$ref": "#/definitions/models.Output-models_Journal"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/{journal_id}/operations": {
+        "/api/v1/admin/journals/{journal_id}/operations": {
             "post": {
                 "security": [
                     {
@@ -1186,28 +1334,28 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Journal"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/{journal_id}/operations/{id}": {
+        "/api/v1/admin/journals/{journal_id}/operations/{id}": {
             "get": {
                 "security": [
                     {
@@ -1215,9 +1363,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get an operation transaction by ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1245,19 +1390,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Transaction"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -1269,9 +1408,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Update an operation transaction by ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1312,19 +1448,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Journal"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -1336,9 +1478,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Delete an operation transaction by ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1366,25 +1505,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Journal"
                         }
                     },
-                    "400": {
-                        "description": "Bad Request",
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/{journal_id}/reopen": {
+        "/api/v1/admin/journals/{journal_id}/reopen": {
             "post": {
                 "security": [
                     {
@@ -1392,9 +1531,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Reopen a journal entry by removing its closing transactions",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1415,22 +1551,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/models.Transaction"
-                            }
+                            "$ref": "#/definitions/models.Output-models_Journal"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/products": {
+        "/api/v1/admin/products": {
             "get": {
                 "security": [
                     {
@@ -1438,9 +1577,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Query products based on various parameters",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1478,19 +1614,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -1527,25 +1663,25 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/products/images/{key}": {
+        "/api/v1/admin/products/images/{key}": {
             "get": {
                 "security": [
                     {
@@ -1591,7 +1727,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/products/transfer": {
+        "/api/v1/admin/products/transfer": {
             "post": {
                 "security": [
                     {
@@ -1599,9 +1735,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Transfers product quantity from one location to another",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1609,10 +1742,23 @@ const docTemplate = `{
                     "products"
                 ],
                 "summary": "Transfer product between locations",
-                "responses": {}
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Output-array_models_Product"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
             }
         },
-        "/api/products/{id}": {
+        "/api/v1/admin/products/{id}": {
             "get": {
                 "security": [
                     {
@@ -1620,9 +1766,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Retrieves a product by its ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1643,13 +1786,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -1693,19 +1836,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -1717,9 +1860,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Deletes a product and its related data",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1740,19 +1880,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/products/{id}/income": {
+        "/api/v1/admin/products/{id}/income": {
             "post": {
                 "security": [
                     {
@@ -1792,31 +1932,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/products/{product_id}/images": {
+        "/api/v1/admin/products/{product_id}/images": {
             "get": {
                 "security": [
                     {
@@ -1844,7 +1984,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -1898,7 +2044,10 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {
@@ -1916,7 +2065,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/products/{product_id}/images/{key}": {
+        "/api/v1/admin/products/{product_id}/images/{key}": {
             "delete": {
                 "security": [
                     {
@@ -1969,7 +2118,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/proposals": {
+        "/api/v1/admin/proposals": {
             "get": {
                 "security": [
                     {
@@ -1977,9 +2126,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Retrieves all proposals with optional filters",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2026,33 +2172,26 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "type": "object",
-                                "additionalProperties": true
+                                "$ref": "#/definitions/models.ProductProposal"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid date format",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to fetch or decode proposals",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/delete": {
+        "/api/v1/admin/proposals/delete": {
             "delete": {
                 "security": [
                     {
@@ -2060,9 +2199,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Deletes a proposal record and its associated image file",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2089,34 +2225,25 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid proposal ID",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Proposal not found",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to delete proposal",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/detail": {
+        "/api/v1/admin/proposals/detail": {
             "get": {
                 "security": [
                     {
@@ -2124,9 +2251,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Retrieves detailed information for a specific proposal record",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "text/html"
                 ],
@@ -2153,25 +2277,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid proposal ID",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Proposal not found",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/edit": {
+        "/api/v1/admin/proposals/edit": {
             "put": {
                 "security": [
                     {
@@ -2180,8 +2298,7 @@ const docTemplate = `{
                 ],
                 "description": "Updates an existing proposal record",
                 "consumes": [
-                    "application/json",
-                    "application/x-www-form-urlencoded"
+                    "application/json"
                 ],
                 "produces": [
                     "application/json"
@@ -2217,25 +2334,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid proposal ID or request data",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to update proposal",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/fulfill": {
+        "/api/v1/admin/proposals/fulfill": {
             "get": {
                 "security": [
                     {
@@ -2243,9 +2354,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Marks multiple proposals as fulfilled for a specific branch",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2273,32 +2381,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Fulfillment result",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid branch or no valid IDs provided",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to fulfill proposals",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/image": {
+        "/api/v1/admin/proposals/image": {
             "get": {
                 "security": [
                     {
@@ -2306,9 +2407,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Retrieves the image upload page for a specific proposal record",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "text/html"
                 ],
@@ -2335,19 +2433,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid proposal ID",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Proposal not found",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -2395,34 +2487,25 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid proposal ID or no file uploaded",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Proposal not found",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to save file or update proposal",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/images": {
+        "/api/v1/admin/proposals/images": {
             "get": {
                 "security": [
                     {
@@ -2430,9 +2513,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Retrieves an image file by its name",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/octet-stream"
                 ],
@@ -2459,16 +2539,13 @@ const docTemplate = `{
                     "404": {
                         "description": "Image not found",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/new": {
+        "/api/v1/admin/proposals/new": {
             "post": {
                 "security": [
                     {
@@ -2511,32 +2588,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Proposals created successfully",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid branch or request body",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to create proposals",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/pdf/pdf": {
+        "/api/v1/admin/proposals/pdf/pdf": {
             "get": {
                 "security": [
                     {
@@ -2544,9 +2614,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Generates a PDF document with unfulfilled proposals",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2558,124 +2625,19 @@ const docTemplate = `{
                     "200": {
                         "description": "PDF generation result with proposals data",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "500": {
                         "description": "Failed to fetch or decode proposals",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/sales/transactions/{branch_id}": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Create a new sales transaction for a branch",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "sales/transactions"
-                ],
-                "summary": "Create a new sales transaction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Branch ID",
-                        "name": "branch_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Transaction details",
-                        "name": "transaction",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.TransactionBase"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/sales/transactions/{transaction_id}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a sales transaction by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "sales/transactions"
-                ],
-                "summary": "Delete a sales transaction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Transaction ID",
-                        "name": "transaction_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/suppliers": {
+        "/api/v1/admin/suppliers": {
             "get": {
                 "security": [
                     {
@@ -2741,13 +2703,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Supplier"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -2784,31 +2746,31 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Supplier"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/suppliers/{branch_id}/{supplier_id}/transactions": {
+        "/api/v1/admin/suppliers/{branch_id}/{supplier_id}/transactions": {
             "post": {
                 "security": [
                     {
@@ -2856,25 +2818,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Transaction"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/suppliers/{id}": {
+        "/api/v1/admin/suppliers/{id}": {
             "get": {
                 "security": [
                     {
@@ -2905,19 +2867,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Supplier"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -2961,25 +2923,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -3014,25 +2976,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/transactions/branch/{branch_id}": {
+        "/api/v1/admin/transactions/branch/{branch_id}": {
             "get": {
                 "security": [
                     {
@@ -3141,7 +3103,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/transactions/docs/initiator_type": {
+        "/api/v1/admin/transactions/docs/initiator_type": {
             "get": {
                 "security": [
                     {
@@ -3172,7 +3134,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/transactions/docs/payment_method": {
+        "/api/v1/admin/transactions/docs/payment_method": {
             "get": {
                 "security": [
                     {
@@ -3203,7 +3165,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/transactions/docs/type": {
+        "/api/v1/admin/transactions/docs/type": {
             "get": {
                 "security": [
                     {
@@ -3234,7 +3196,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/transactions/{id}": {
+        "/api/v1/admin/transactions/{id}": {
             "put": {
                 "security": [
                     {
@@ -3342,7 +3304,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/transactions/{transaction_id}": {
+        "/api/v1/admin/transactions/{transaction_id}": {
             "get": {
                 "security": [
                     {
@@ -3385,58 +3347,152 @@ const docTemplate = `{
                 }
             }
         },
-        "/auth/login": {
-            "post": {
-                "description": "Authenticate user and return a token",
-                "consumes": [
-                    "application/json"
+        "/api/v1/store/account/addresses": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
                 ],
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "auth"
+                    "store-account"
                 ],
-                "summary": "Login a user",
-                "parameters": [
-                    {
-                        "description": "User credentials",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
+                "summary": "List the customer's saved addresses",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
-                            "$ref": "#/definitions/auth.LoginInput"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
                 ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-account"
+                ],
+                "summary": "Add a new address to the customer's address book",
                 "responses": {
-                    "200": {
-                        "description": "token",
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/auth/register": {
+        "/api/v1/store/account/addresses/{address_id}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-account"
+                ],
+                "summary": "Update an address",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Address ID",
+                        "name": "address_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-account"
+                ],
+                "summary": "Delete an address",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Address ID",
+                        "name": "address_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/account/addresses/{address_id}/default": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-account"
+                ],
+                "summary": "Mark an address as the default",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Address ID",
+                        "name": "address_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/login": {
             "post": {
-                "description": "Create a new user account",
+                "description": "Authenticate a storefront customer and return a token",
                 "consumes": [
                     "application/json"
                 ],
@@ -3444,31 +3500,1183 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "auth"
+                    "store-auth"
                 ],
-                "summary": "Register a new user",
+                "summary": "Login a storefront customer",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/logout": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Logout the current storefront customer",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/me": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Get current storefront customer profile",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Update current storefront customer profile",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/password/forgot": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Request a password reset",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/password/reset": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Reset a password with a reset token",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/refresh": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Refresh a storefront access token",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/register": {
+            "post": {
+                "description": "Create a new storefront customer account",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Register a storefront customer",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/cart": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Get the current customer's cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Empty the cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/cart/items": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Add an item to the cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/cart/items/{item_id}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Update a cart item's quantity",
                 "parameters": [
                     {
-                        "description": "User credentials",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.User"
-                        }
+                        "type": "string",
+                        "description": "Cart item ID",
+                        "name": "item_id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
-                    "201": {
-                        "description": "Created",
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Remove an item from the cart",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cart item ID",
+                        "name": "item_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/cart/promo": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Apply a coupon code to the cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Remove the applied coupon from the cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/catalog/brands": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-catalog"
+                ],
+                "summary": "List brands / manufacturers",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/catalog/categories": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-catalog"
+                ],
+                "summary": "List catalog categories",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/catalog/categories/{id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-catalog"
+                ],
+                "summary": "Get a category by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Category ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/catalog/categories/{id}/products": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-catalog"
+                ],
+                "summary": "List products in a category",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Category ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/catalog/search": {
+            "get": {
+                "description": "Full-text search with filters, facets, sort and pagination",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-catalog"
+                ],
+                "summary": "Search the catalog",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/checkout/preview": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Preview checkout totals (items, shipping, tax) before placing an order",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/orders": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "List the customer's orders",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Place an order from the current cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/orders/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Get an order by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/orders/{id}/cancel": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Cancel an order",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/orders/{id}/reorder": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Re-add the items of a past order to the cart",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/orders/{id}/status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Get an order's status / tracking",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products": {
+            "get": {
+                "description": "List products with filter/sort/pagination",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "List storefront products",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page",
+                        "name": "count",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products/{id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "Get a storefront product by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products/{id}/availability": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "Get a product's stock availability per branch",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products/{id}/images": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "Get a product's images",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products/{id}/related": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "Get related / recommended products",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products/{id}/reviews": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "List reviews for a product (public)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-reviews"
+                ],
+                "summary": "Create a review for a product",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/promotions": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-promotions"
+                ],
+                "summary": "List active promotions / banners",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/promotions/coupons/{code}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-promotions"
+                ],
+                "summary": "Look up a coupon's terms by code",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Coupon code",
+                        "name": "code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/promotions/validate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-promotions"
+                ],
+                "summary": "Validate a coupon against the current cart / customer",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/promotions/{id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-promotions"
+                ],
+                "summary": "Get a promotion by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Promotion ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/reviews/{id}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-reviews"
+                ],
+                "summary": "Update the caller's own review",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-reviews"
+                ],
+                "summary": "Delete the caller's own review",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/reviews/{id}/vote": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-reviews"
+                ],
+                "summary": "Vote a review helpful / unhelpful",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/wishlist": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-wishlist"
+                ],
+                "summary": "Get the current customer's wishlist",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/wishlist/items": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-wishlist"
+                ],
+                "summary": "Add a product to the wishlist",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/wishlist/items/{product_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-wishlist"
+                ],
+                "summary": "Remove a product from the wishlist",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "product_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/wishlist/items/{product_id}/move-to-cart": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-wishlist"
+                ],
+                "summary": "Move a wishlist product into the cart",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "product_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -3559,6 +4767,90 @@ const docTemplate = `{
                 }
             }
         },
+        "middleware.Activity": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "$ref": "#/definitions/middleware.ActivityType"
+                },
+                "data": {},
+                "date": {
+                    "type": "string"
+                },
+                "ip": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "integer"
+                },
+                "userID": {
+                    "type": "string"
+                }
+            }
+        },
+        "middleware.ActivityType": {
+            "type": "string",
+            "enum": [
+                "login_success",
+                "login_failed",
+                "logout_success",
+                "logout_failed",
+                "register_success",
+                "register_failed",
+                "create_transaction",
+                "create_journal",
+                "close_journal",
+                "create_supplier",
+                "create_product",
+                "edit_transaction",
+                "edit_supplier",
+                "edit_product",
+                "delete_transaction",
+                "reopen_journal",
+                "delete_supplier",
+                "delete_product",
+                "close_sales_session",
+                "open_sales_session",
+                "product_income",
+                "product_transfer",
+                "create_operation",
+                "edit_operation",
+                "delete_operation",
+                "create_finance",
+                "edit_finance",
+                "delete_finance"
+            ],
+            "x-enum-varnames": [
+                "ActivityTypeLogin",
+                "ActivityTypeLoginFailed",
+                "ActivityTypeLogout",
+                "ActivityTypeLogoutFailed",
+                "ActivityTypeRegister",
+                "ActivityTypeRegisterFailed",
+                "ActivityTypeCreateTransaction",
+                "ActivityTypeCreateJournal",
+                "ActivityTypeCloseJournal",
+                "ActivityTypeCreateSupplier",
+                "ActivityTypeCreateProduct",
+                "ActivityTypeEditTransaction",
+                "ActivityTypeEditSupplier",
+                "ActivityTypeEditProduct",
+                "ActivityTypeDeleteTransaction",
+                "ActivityTypeReopenJournal",
+                "ActivityTypeDeleteSupplier",
+                "ActivityTypeDeleteProduct",
+                "ActivityTypeCloseSalesSession",
+                "ActivityTypeOpenSalesSession",
+                "ActivityTypeProductIncome",
+                "ActivityTypeProductTransfer",
+                "ActivityTypeCreateOperation",
+                "ActivityTypeEditOperation",
+                "ActivityTypeDeleteOperation",
+                "ActivityTypeCreateFinance",
+                "ActivityTypeEditFinance",
+                "ActivityTypeDeleteFinance"
+            ]
+        },
         "models.BNPL": {
             "type": "object",
             "properties": {
@@ -3620,6 +4912,23 @@ const docTemplate = `{
                 "BNPLStatusCancelled"
             ]
         },
+        "models.Balance": {
+            "type": "object",
+            "properties": {
+                "bank": {
+                    "type": "integer"
+                },
+                "cash": {
+                    "type": "integer"
+                },
+                "mobile_apps": {
+                    "type": "integer"
+                },
+                "terminal": {
+                    "type": "integer"
+                }
+            }
+        },
         "models.Branch": {
             "type": "object",
             "properties": {
@@ -3637,6 +4946,36 @@ const docTemplate = `{
                 }
             }
         },
+        "models.BranchFinance": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "$ref": "#/definitions/models.Balance"
+                },
+                "branch_id": {
+                    "type": "string"
+                },
+                "branch_name": {
+                    "type": "string"
+                },
+                "debt": {
+                    "type": "integer"
+                },
+                "details": {},
+                "suppliers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "total_expenses": {
+                    "type": "integer"
+                },
+                "total_income": {
+                    "type": "integer"
+                }
+            }
+        },
         "models.CloseJournalEntryInput": {
             "type": "object",
             "properties": {
@@ -3645,6 +4984,49 @@ const docTemplate = `{
                 },
                 "terminal_income": {
                     "type": "integer"
+                }
+            }
+        },
+        "models.Customer": {
+            "type": "object",
+            "properties": {
+                "additional_info": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "address": {
+                    "description": "Email   string ` + "`" + `json:\"email\" bson:\"email\"` + "`" + `",
+                    "type": "string"
+                },
+                "bnpls": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.BNPL"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "purchase_history": {
+                    "description": "purchase history is updated when a customer a sales session or completes a BNPL session",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.SalesSession"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },
@@ -3669,6 +5051,43 @@ const docTemplate = `{
                 }
             }
         },
+        "models.CustomerQueryOutput": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CustomerQueryOutputData"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.CustomerQueryOutputData": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "customers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Customer"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
         "models.Error": {
             "type": "object",
             "properties": {
@@ -3677,6 +5096,70 @@ const docTemplate = `{
                 },
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "models.ErrorOutput": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {}
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.FinancialData": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "type": "integer"
+                },
+                "total_expenses": {
+                    "type": "integer"
+                },
+                "total_income": {
+                    "type": "integer"
+                },
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Transaction"
+                    }
+                }
+            }
+        },
+        "models.IncomeHistory": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "description": "Date of the income",
+                    "type": "string"
+                },
+                "price": {
+                    "description": "Price of the product that was uploaded",
+                    "type": "integer"
+                },
+                "quantity": {
+                    "description": "Quantity of the product that was uploaded",
+                    "type": "integer"
+                },
+                "supplier_id": {
+                    "description": "Supplier ID",
+                    "type": "string"
+                },
+                "uploaded_to": {
+                    "description": "Place where the product was uploaded to",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.ProductPlace"
+                        }
+                    ]
                 }
             }
         },
@@ -3759,6 +5242,38 @@ const docTemplate = `{
                 }
             }
         },
+        "models.JournalWithTransactionID": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "$ref": "#/definitions/models.Branch"
+                },
+                "cash_left": {
+                    "type": "integer"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "shift_is_closed": {
+                    "type": "boolean"
+                },
+                "terminal_income": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
         "models.ManufacturerInfo": {
             "type": "object",
             "properties": {
@@ -3780,6 +5295,14 @@ const docTemplate = `{
                 },
                 "phone": {
                     "description": "Contact phone number",
+                    "type": "string"
+                }
+            }
+        },
+        "models.MessageResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
                     "type": "string"
                 }
             }
@@ -3827,10 +5350,201 @@ const docTemplate = `{
                 }
             }
         },
-        "models.Output": {
+        "models.Output-array_middleware_Activity": {
             "type": "object",
             "properties": {
-                "data": {},
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/middleware.Activity"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_BNPL": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.BNPL"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_BranchFinance": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.BranchFinance"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_Customer": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Customer"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_Journal": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Journal"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_Product": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Product"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_Supplier": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Supplier"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_BNPL": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.BNPL"
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_BranchFinance": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.BranchFinance"
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_Journal": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.Journal"
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_JournalWithTransactionID": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.JournalWithTransactionID"
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_Supplier": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.Supplier"
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_Transaction": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.Transaction"
+                },
                 "error": {
                     "type": "array",
                     "items": {
@@ -3859,6 +5573,79 @@ const docTemplate = `{
                 "OnlineTransfer",
                 "PaymentMethodUndefined"
             ]
+        },
+        "models.Product": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "description": "Product categories",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "description": "Creation timestamp",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Product description",
+                    "type": "string"
+                },
+                "general_income_price": {
+                    "description": "General income price of the product --- the price generally this item is bought from supplier",
+                    "type": "number"
+                },
+                "id": {
+                    "description": "Unique product identifier",
+                    "type": "string"
+                },
+                "images": {
+                    "description": "Product images (lins) saved to some S3",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "income_history": {
+                    "description": "Income history",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.IncomeHistory"
+                    }
+                },
+                "manufacturer": {
+                    "description": "Manufacturer details",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.ManufacturerInfo"
+                        }
+                    ]
+                },
+                "minimum_stock_alert": {
+                    "description": "Minimum stock alert",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "Product name",
+                    "type": "string"
+                },
+                "quantity_distribution": {
+                    "description": "Stock levels by location",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ProductDistribution"
+                    }
+                },
+                "sku": {
+                    "description": "Stock Keeping Unit",
+                    "type": "string"
+                },
+                "updated_at": {
+                    "description": "Last update timestamp",
+                    "type": "string"
+                }
+            }
         },
         "models.ProductBase": {
             "type": "object",
@@ -3900,6 +5687,31 @@ const docTemplate = `{
                 }
             }
         },
+        "models.ProductDistribution": {
+            "type": "object",
+            "properties": {
+                "place": {
+                    "description": "Location details",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.ProductPlace"
+                        }
+                    ]
+                },
+                "price": {
+                    "description": "Price of the product",
+                    "type": "integer"
+                },
+                "quantity": {
+                    "description": "Quantity of the product",
+                    "type": "integer"
+                },
+                "unit": {
+                    "description": "Unit of measurement (e.g. kg, pieces, etc)",
+                    "type": "string"
+                }
+            }
+        },
         "models.ProductPlace": {
             "type": "object",
             "properties": {
@@ -3932,6 +5744,50 @@ const docTemplate = `{
                 "ProductPlaceTypeWarehouse"
             ]
         },
+        "models.ProductProposal": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "fulfilled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "image_file": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.SalesSession": {
+            "type": "object",
+            "properties": {
+                "branch_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "product_items": {
+                    "description": "product which are going to be sold",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/models.SalesSessionItem"
+                    }
+                }
+            }
+        },
         "models.SalesSessionItem": {
             "type": "object",
             "properties": {
@@ -3940,6 +5796,44 @@ const docTemplate = `{
                 },
                 "quantity": {
                     "type": "integer"
+                }
+            }
+        },
+        "models.Supplier": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "branch": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "financial_data": {
+                    "$ref": "#/definitions/models.FinancialData"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "inn": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },
@@ -3965,6 +5859,32 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "phone": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TokenResponse": {
+            "type": "object",
+            "properties": {
+                "aud": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "string"
+                },
+                "exp": {
+                    "type": "string"
+                },
+                "iat": {
+                    "type": "string"
+                },
+                "jti": {
+                    "type": "string"
+                },
+                "nbf": {
+                    "type": "string"
+                },
+                "sub": {
                     "type": "string"
                 }
             }
@@ -4061,16 +5981,13 @@ const docTemplate = `{
                 "TransactionTypeDebit"
             ]
         },
-        "models.User": {
+        "models.UserRegisterInput": {
             "type": "object",
             "properties": {
                 "branch": {
                     "type": "string"
                 },
                 "email": {
-                    "type": "string"
-                },
-                "id": {
                     "type": "string"
                 },
                 "password": {

--- a/docs/storefront-implementation-guide.md
+++ b/docs/storefront-implementation-guide.md
@@ -1,0 +1,288 @@
+# Storefront Implementation Guide — Models, Repositories & Controllers
+
+This guide defines the layering for implementing the storefront (`/api/v1/store`)
+Phase-2 logic, and is the pattern all new store domains must follow.
+
+## Goals (from the requirements)
+
+1. **Models** live in `pkg/models` (new package).
+2. **Repositories** live in `pkg/repository/...` and implement *all* database operations.
+3. Each controller holds its repository as a **struct field** and reaches it from handlers.
+4. **Handlers never touch the database** — no `mongo`/`bson`, no `db.Collection(...)`.
+   They parse the request, call a repository method, and render the response envelope.
+
+## Layering
+
+```
+HTTP request
+  └─ Controller handler  (pkg/controllers/store/<domain>)   ← parse req, map result→HTTP
+       └─ Repository      (pkg/repository/store/<domain>)    ← all mongo/bson lives here
+            └─ Model       (pkg/models)                       ← plain structs + DTOs
+```
+
+A handler depends on its repository and on the response helpers — **not** on mongo.
+
+## Package layout & the transition
+
+`pkg/repository` is **currently the `models` package** (the legacy structs `Customer`,
+`Product`, `Output`, … sit in `pkg/repository/*.go` as `package models`). Those will move
+to `pkg/models` *later*. Until then, to avoid two `package models` directories colliding,
+new code is placed as follows:
+
+| Concern | Location | Package |
+|---|---|---|
+| New store models | `pkg/models/<domain>.go` | `models` |
+| Store repositories | `pkg/repository/store/<domain>/` | `<domain>` (e.g. `cart`) |
+| Shared repo errors | `pkg/repository/repoerr/` | `repoerr` |
+| Response envelope (legacy, stays for now) | `pkg/repository/output.go` | `models` |
+| Store controllers | `pkg/controllers/store/<domain>/` | `store<domain>` |
+
+**Import aliases** keep the two `models` packages unambiguous in a controller:
+
+```go
+import (
+    "github.com/aslon1213/g4h_pos_erp/pkg/models"                       // new data models  → models.Cart
+    resp "github.com/aslon1213/g4h_pos_erp/pkg/repository"              // legacy envelope  → resp.NewOutput
+    cartrepo "github.com/aslon1213/g4h_pos_erp/pkg/repository/store/cart"
+    "github.com/aslon1213/g4h_pos_erp/pkg/repository/repoerr"
+)
+```
+
+> When the legacy structs migrate to `pkg/models`, the `Output`/`NewOutput`/`NotImplemented`
+> helpers move with them and the `resp` alias collapses to plain `models`. Nothing else changes.
+
+## Conventions
+
+- **IDs are `string` (uuid)**, matching existing `Customer`/`Product`/`User`. This keeps
+  `pkg/models` free of any mongo import (`bson:"_id"` is just a struct tag).
+- **Repository owns mongo**: `bson`, `mongo`, `options`, indexes, aggregation pipelines.
+- **Repository method signature**: `(ctx context.Context, …) (*models.X, error)` — always
+  takes `ctx` (handler passes `c.Context()`), returns a model + error.
+- **Repository translates mongo errors → sentinels** (`repoerr.ErrNotFound`, `repoerr.ErrConflict`)
+  so controllers map them to HTTP status without importing mongo.
+- **Indexes** are created in the repository `New(db)` constructor (mirrors `finance.New`).
+- **Constructor**: controller `New(db *mongo.Database)` builds the repo — the *only* place a
+  store controller references `mongo` (just the `*mongo.Database` parameter type).
+
+## What changes vs. today
+
+Today handlers call the DB directly (anti-pattern we are replacing):
+
+```go
+// pkg/controllers/finance/finance.go  (current — DB in the handler)
+cursor, err := f.FinanceCollection.Find(context.Background(), bson.M{})
+```
+
+After this pattern, the handler calls a repository method and never sees mongo/bson.
+
+---
+
+## Worked example — Cart
+
+### 1. Model — `pkg/models/cart.go`
+
+```go
+package models
+
+import "time"
+
+type CartItem struct {
+    ID        string  `json:"id" bson:"id"`
+    ProductID string  `json:"product_id" bson:"product_id"`
+    Quantity  int     `json:"quantity" bson:"quantity"`
+    UnitPrice float64 `json:"unit_price" bson:"unit_price"`
+}
+
+type Cart struct {
+    ID         string     `json:"id" bson:"_id"`
+    CustomerID string     `json:"customer_id" bson:"customer_id"`
+    Items      []CartItem `json:"items" bson:"items"`
+    CouponCode string     `json:"coupon_code" bson:"coupon_code"`
+    CreatedAt  time.Time  `json:"created_at" bson:"created_at"`
+    UpdatedAt  time.Time  `json:"updated_at" bson:"updated_at"`
+}
+
+// AddCartItemInput is the request DTO for POST /cart/items.
+type AddCartItemInput struct {
+    ProductID string `json:"product_id"`
+    Quantity  int    `json:"quantity"`
+}
+```
+
+### 2. Shared errors — `pkg/repository/repoerr/errors.go`
+
+```go
+package repoerr
+
+import "errors"
+
+var (
+    ErrNotFound = errors.New("resource not found")
+    ErrConflict = errors.New("resource already exists")
+)
+```
+
+### 3. Repository — `pkg/repository/store/cart/cart_repository.go`
+
+```go
+package cart
+
+import (
+    "context"
+    "errors"
+    "time"
+
+    "github.com/aslon1213/g4h_pos_erp/pkg/models"
+    "github.com/aslon1213/g4h_pos_erp/pkg/repository/repoerr"
+    "go.mongodb.org/mongo-driver/v2/bson"
+    "go.mongodb.org/mongo-driver/v2/mongo"
+    "go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+type Repository struct {
+    coll *mongo.Collection
+}
+
+func New(db *mongo.Database) *Repository {
+    coll := db.Collection("carts")
+    _, _ = coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
+        Keys:    bson.D{{Key: "customer_id", Value: 1}},
+        Options: options.Index().SetUnique(true),
+    })
+    return &Repository{coll: coll}
+}
+
+// GetByCustomer returns the customer's cart, or repoerr.ErrNotFound.
+func (r *Repository) GetByCustomer(ctx context.Context, customerID string) (*models.Cart, error) {
+    cart := &models.Cart{}
+    err := r.coll.FindOne(ctx, bson.M{"customer_id": customerID}).Decode(cart)
+    if errors.Is(err, mongo.ErrNoDocuments) {
+        return nil, repoerr.ErrNotFound
+    }
+    if err != nil {
+        return nil, err
+    }
+    return cart, nil
+}
+
+// AddItem upserts the customer's cart and appends an item.
+func (r *Repository) AddItem(ctx context.Context, customerID string, item models.CartItem) (*models.Cart, error) {
+    now := time.Now()
+    update := bson.M{
+        "$push":        bson.M{"items": item},
+        "$set":         bson.M{"updated_at": now},
+        "$setOnInsert": bson.M{"customer_id": customerID, "created_at": now},
+    }
+    opts := options.UpdateOne().SetUpsert(true)
+    if _, err := r.coll.UpdateOne(ctx, bson.M{"customer_id": customerID}, update, opts); err != nil {
+        return nil, err
+    }
+    return r.GetByCustomer(ctx, customerID)
+}
+```
+
+### 4. Response helpers — add to `pkg/repository/output.go` (package `models`)
+
+```go
+import "github.com/aslon1213/g4h_pos_erp/pkg/repository/repoerr" // + "errors"
+
+func RespondError(c *fiber.Ctx, code int, msg string) error {
+    return c.Status(code).JSON(NewOutput(nil, NewError(msg, code)))
+}
+
+// RespondRepoError maps repository sentinel errors to HTTP responses so every
+// handler can do `return resp.RespondRepoError(c, err)`.
+func RespondRepoError(c *fiber.Ctx, err error) error {
+    switch {
+    case errors.Is(err, repoerr.ErrNotFound):
+        return RespondError(c, fiber.StatusNotFound, err.Error())
+    case errors.Is(err, repoerr.ErrConflict):
+        return RespondError(c, fiber.StatusConflict, err.Error())
+    default:
+        return RespondError(c, fiber.StatusInternalServerError, err.Error())
+    }
+}
+```
+
+### 5. Controller — `pkg/controllers/store/cart/cart.go`
+
+```go
+package storecart
+
+import (
+    "errors"
+
+    "github.com/aslon1213/g4h_pos_erp/pkg/models"
+    resp "github.com/aslon1213/g4h_pos_erp/pkg/repository"
+    cartrepo "github.com/aslon1213/g4h_pos_erp/pkg/repository/store/cart"
+    "github.com/gofiber/fiber/v2"
+    "github.com/google/uuid"
+    "go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+type Controller struct {
+    Repo *cartrepo.Repository
+}
+
+func New(db *mongo.Database) *Controller {
+    return &Controller{Repo: cartrepo.New(db)}
+}
+
+// GetCart godoc … (swaggo unchanged)
+func (ctrl *Controller) GetCart(c *fiber.Ctx) error {
+    customerID := c.Locals("customer").(string) // set by CustomerAuthMiddleware
+    cart, err := ctrl.Repo.GetByCustomer(c.Context(), customerID)
+    if err != nil {
+        return resp.RespondRepoError(c, err)
+    }
+    return c.JSON(resp.NewOutput(cart))
+}
+
+func (ctrl *Controller) AddItem(c *fiber.Ctx) error {
+    customerID := c.Locals("customer").(string)
+    var in models.AddCartItemInput
+    if err := c.BodyParser(&in); err != nil {
+        return resp.RespondError(c, fiber.StatusBadRequest, "invalid request body")
+    }
+    item := models.CartItem{ID: uuid.New().String(), ProductID: in.ProductID, Quantity: in.Quantity}
+    cart, err := ctrl.Repo.AddItem(c.Context(), customerID, item)
+    if err != nil {
+        return resp.RespondRepoError(c, err)
+    }
+    return c.Status(fiber.StatusCreated).JSON(resp.NewOutput(cart))
+}
+```
+
+Notice: the handler imports `errors`/`uuid`/`models`/`resp`/`cartrepo` — **no `bson`, no
+`db.Collection`, no query logic.** `mongo` appears only in the `New` constructor signature.
+
+---
+
+## Adding a new store domain — checklist
+
+1. **Model** → `pkg/models/<domain>.go`: `<Domain>`, nested types, `<Action>Input` DTOs. String IDs.
+2. **Repository** → `pkg/repository/store/<domain>/<domain>_repository.go`: `Repository` struct,
+   `New(db)` (with indexes), one method per data operation, mongo→`repoerr` translation.
+3. **Controller** → add `Repo *<domain>repo.Repository` field; `New(db)` builds it; replace each
+   stubbed `models.NotImplemented(c)` body with parse → `ctrl.Repo.X(...)` → `resp.NewOutput`.
+4. Routes & wiring already exist (Phase 1) — no changes to `routes/store.go` or `SetupRoutes`.
+5. **Build & verify**: `go build ./...`, then boot and exercise the endpoint (a valid
+   32-byte `SERVER_SECRET_SYMMETRIC_KEY` is required — see note below).
+
+## Suggested domain order
+
+`auth` + `account` first (everything customer-scoped needs `store_customers` + the
+`StoreCustomer` model fleshed out: password hash via `bcrypt`, token issuance via
+`pasetoware.CreateToken` as in admin `auth.Login`), then `catalog`/`products` (read-only over
+`products`), then `cart` → `wishlist` → `orders` → `reviews` → `promotions`.
+
+## Notes
+
+- **Reuse, don't duplicate**: catalog/products repositories read the existing `products`
+  collection; reviews repository can be shared between the public listing handler
+  (`storeproducts.GetProductReviews`) and the write handlers (`storereviews.*`).
+- **Local boot** currently needs a valid key: `config.local.yaml`'s `secret_symmetric_key`
+  decodes to 24 bytes but PASETO needs 32 — override with
+  `SERVER_SECRET_SYMMETRIC_KEY=$(openssl rand -base64 32)` or fix the config.
+- This guide intentionally does **not** migrate the legacy `pkg/repository` structs yet; that is
+  a separate, mechanical follow-up once the store domains are on the new pattern.

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -16,7 +16,108 @@
         "version": "1.0"
     },
     "paths": {
-        "/api/activities/me": {
+        "/api/sales/transactions/{branch_id}": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new sales transaction for a branch",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sales/transactions"
+                ],
+                "summary": "Create a new sales transaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Branch ID",
+                        "name": "branch_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Transaction details",
+                        "name": "transaction",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TransactionBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Output-models_Transaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/sales/transactions/{transaction_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a sales transaction by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sales/transactions"
+                ],
+                "summary": "Delete a sales transaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Transaction ID",
+                        "name": "transaction_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Output-models_Transaction"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/activities/me": {
             "get": {
                 "security": [
                     {
@@ -24,9 +125,6 @@
                     }
                 ],
                 "description": "Get the 25 most recent activities for the authenticated user",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -38,19 +136,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_middleware_Activity"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/activities/recent": {
+        "/api/v1/admin/activities/recent": {
             "get": {
                 "security": [
                     {
@@ -58,9 +156,6 @@
                     }
                 ],
                 "description": "Get the 25 most recent activities across all users",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -72,19 +167,65 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_middleware_Activity"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/auth/me": {
+        "/api/v1/admin/auth/login": {
+            "post": {
+                "description": "Authenticate user and return a token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Login a user",
+                "parameters": [
+                    {
+                        "description": "User credentials",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/auth.LoginInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "token",
+                        "schema": {
+                            "$ref": "#/definitions/models.TokenResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/auth/me": {
             "get": {
                 "security": [
                     {
@@ -92,9 +233,6 @@
                     }
                 ],
                 "description": "Get user info",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -106,22 +244,19 @@
                     "200": {
                         "description": "message",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/bnpl": {
+        "/api/v1/admin/bnpl": {
             "post": {
                 "security": [
                     {
@@ -154,25 +289,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_BNPL"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/bnpl/{id}": {
+        "/api/v1/admin/bnpl/{id}": {
             "get": {
                 "security": [
                     {
@@ -180,9 +315,6 @@
                     }
                 ],
                 "description": "Get details of a specific BNPL transaction",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -203,13 +335,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_BNPL"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -221,9 +353,6 @@
                     }
                 ],
                 "description": "Delete an existing BNPL transaction",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -244,22 +373,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/bnpl/{id}/credit": {
+        "/api/v1/admin/bnpl/{id}/credit": {
             "post": {
                 "security": [
                     {
@@ -304,19 +430,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.BNPL"
+                            "$ref": "#/definitions/models.Output-array_models_BNPL"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/branches/{branch_id}/bnpls": {
+        "/api/v1/admin/branches/{branch_id}/bnpls": {
             "get": {
                 "security": [
                     {
@@ -324,9 +450,6 @@
                     }
                 ],
                 "description": "Get all BNPL transactions for a specific branch",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -365,19 +488,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Customer"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/customers": {
+        "/api/v1/admin/customers": {
             "get": {
                 "security": [
                     {
@@ -437,13 +560,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.CustomerQueryOutput"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -480,25 +609,31 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Customer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/customers/{customer_id}/bnpls": {
+        "/api/v1/admin/customers/{customer_id}/bnpls": {
             "get": {
                 "security": [
                     {
@@ -506,9 +641,6 @@
                     }
                 ],
                 "description": "Get all BNPL transactions for a specific customer",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -535,19 +667,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_BNPL"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/customers/{id}": {
+        "/api/v1/admin/customers/{id}": {
             "get": {
                 "security": [
                     {
@@ -555,9 +687,6 @@
                     }
                 ],
                 "description": "Get a customer by its ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -578,19 +707,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Customer"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -634,25 +763,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Customer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -664,9 +799,6 @@
                     }
                 ],
                 "description": "Delete a customer from the database",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -687,25 +819,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.MessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/finance": {
+        "/api/v1/admin/finance": {
             "post": {
                 "security": [
                     {
@@ -738,25 +876,25 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_BranchFinance"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/finance/branch/id/{id}": {
+        "/api/v1/admin/finance/branch/id/{id}": {
             "get": {
                 "security": [
                     {
@@ -784,19 +922,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_BranchFinance"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/finance/branch/name/{branch_name}": {
+        "/api/v1/admin/finance/branch/name/{branch_name}": {
             "get": {
                 "security": [
                     {
@@ -824,19 +962,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_BranchFinance"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/finance/branches": {
+        "/api/v1/admin/finance/branches": {
             "get": {
                 "security": [
                     {
@@ -855,19 +993,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_BranchFinance"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/finance/id/{id}": {
+        "/api/v1/admin/finance/id/{id}": {
             "get": {
                 "security": [
                     {
@@ -895,19 +1033,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_BranchFinance"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals": {
+        "/api/v1/admin/journals": {
             "post": {
                 "security": [
                     {
@@ -940,25 +1084,25 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Journal"
+                            "$ref": "#/definitions/models.Output-models_JournalWithTransactionID"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/branch/{branch_id}": {
+        "/api/v1/admin/journals/branch/{branch_id}": {
             "get": {
                 "security": [
                     {
@@ -966,9 +1110,6 @@
                     }
                 ],
                 "description": "Query journal entries by branch ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1001,22 +1142,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/models.Journal"
-                            }
+                            "$ref": "#/definitions/models.Output-array_models_Journal"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/report": {
+        "/api/v1/admin/journals/report": {
             "get": {
                 "security": [
                     {
@@ -1024,9 +1168,6 @@
                     }
                 ],
                 "description": "Get a report of journal entries",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1034,10 +1175,23 @@
                     "journals"
                 ],
                 "summary": "Get a report",
-                "responses": {}
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.MessageResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
             }
         },
-        "/api/journals/{journal_id}": {
+        "/api/v1/admin/journals/{journal_id}": {
             "get": {
                 "security": [
                     {
@@ -1045,9 +1199,6 @@
                     }
                 ],
                 "description": "Get a journal entry by its ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1068,19 +1219,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Journal"
+                            "$ref": "#/definitions/models.Output-models_Journal"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/{journal_id}/close": {
+        "/api/v1/admin/journals/{journal_id}/close": {
             "post": {
                 "security": [
                     {
@@ -1117,31 +1268,28 @@
                     }
                 ],
                 "responses": {
-                    "201": {
-                        "description": "Created",
+                    "200": {
+                        "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/models.Transaction"
-                            }
+                            "$ref": "#/definitions/models.Output-models_Journal"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/{journal_id}/operations": {
+        "/api/v1/admin/journals/{journal_id}/operations": {
             "post": {
                 "security": [
                     {
@@ -1178,28 +1326,28 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Journal"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/{journal_id}/operations/{id}": {
+        "/api/v1/admin/journals/{journal_id}/operations/{id}": {
             "get": {
                 "security": [
                     {
@@ -1207,9 +1355,6 @@
                     }
                 ],
                 "description": "Get an operation transaction by ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1237,19 +1382,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Transaction"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -1261,9 +1400,6 @@
                     }
                 ],
                 "description": "Update an operation transaction by ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1304,19 +1440,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Journal"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -1328,9 +1470,6 @@
                     }
                 ],
                 "description": "Delete an operation transaction by ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1358,25 +1497,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Journal"
                         }
                     },
-                    "400": {
-                        "description": "Bad Request",
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/journals/{journal_id}/reopen": {
+        "/api/v1/admin/journals/{journal_id}/reopen": {
             "post": {
                 "security": [
                     {
@@ -1384,9 +1523,6 @@
                     }
                 ],
                 "description": "Reopen a journal entry by removing its closing transactions",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1407,22 +1543,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/models.Transaction"
-                            }
+                            "$ref": "#/definitions/models.Output-models_Journal"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Error"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/products": {
+        "/api/v1/admin/products": {
             "get": {
                 "security": [
                     {
@@ -1430,9 +1569,6 @@
                     }
                 ],
                 "description": "Query products based on various parameters",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1470,19 +1606,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -1519,25 +1655,25 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/products/images/{key}": {
+        "/api/v1/admin/products/images/{key}": {
             "get": {
                 "security": [
                     {
@@ -1583,7 +1719,7 @@
                 }
             }
         },
-        "/api/products/transfer": {
+        "/api/v1/admin/products/transfer": {
             "post": {
                 "security": [
                     {
@@ -1591,9 +1727,6 @@
                     }
                 ],
                 "description": "Transfers product quantity from one location to another",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1601,10 +1734,23 @@
                     "products"
                 ],
                 "summary": "Transfer product between locations",
-                "responses": {}
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Output-array_models_Product"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
             }
         },
-        "/api/products/{id}": {
+        "/api/v1/admin/products/{id}": {
             "get": {
                 "security": [
                     {
@@ -1612,9 +1758,6 @@
                     }
                 ],
                 "description": "Retrieves a product by its ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1635,13 +1778,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -1685,19 +1828,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -1709,9 +1852,6 @@
                     }
                 ],
                 "description": "Deletes a product and its related data",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1732,19 +1872,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/products/{id}/income": {
+        "/api/v1/admin/products/{id}/income": {
             "post": {
                 "security": [
                     {
@@ -1784,31 +1924,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Product"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/products/{product_id}/images": {
+        "/api/v1/admin/products/{product_id}/images": {
             "get": {
                 "security": [
                     {
@@ -1836,7 +1976,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -1890,7 +2036,10 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {
@@ -1908,7 +2057,7 @@
                 }
             }
         },
-        "/api/products/{product_id}/images/{key}": {
+        "/api/v1/admin/products/{product_id}/images/{key}": {
             "delete": {
                 "security": [
                     {
@@ -1961,7 +2110,7 @@
                 }
             }
         },
-        "/api/proposals": {
+        "/api/v1/admin/proposals": {
             "get": {
                 "security": [
                     {
@@ -1969,9 +2118,6 @@
                     }
                 ],
                 "description": "Retrieves all proposals with optional filters",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2018,33 +2164,26 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "type": "object",
-                                "additionalProperties": true
+                                "$ref": "#/definitions/models.ProductProposal"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid date format",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to fetch or decode proposals",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/delete": {
+        "/api/v1/admin/proposals/delete": {
             "delete": {
                 "security": [
                     {
@@ -2052,9 +2191,6 @@
                     }
                 ],
                 "description": "Deletes a proposal record and its associated image file",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2081,34 +2217,25 @@
                     "400": {
                         "description": "Invalid proposal ID",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Proposal not found",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to delete proposal",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/detail": {
+        "/api/v1/admin/proposals/detail": {
             "get": {
                 "security": [
                     {
@@ -2116,9 +2243,6 @@
                     }
                 ],
                 "description": "Retrieves detailed information for a specific proposal record",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "text/html"
                 ],
@@ -2145,25 +2269,19 @@
                     "400": {
                         "description": "Invalid proposal ID",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Proposal not found",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/edit": {
+        "/api/v1/admin/proposals/edit": {
             "put": {
                 "security": [
                     {
@@ -2172,8 +2290,7 @@
                 ],
                 "description": "Updates an existing proposal record",
                 "consumes": [
-                    "application/json",
-                    "application/x-www-form-urlencoded"
+                    "application/json"
                 ],
                 "produces": [
                     "application/json"
@@ -2209,25 +2326,19 @@
                     "400": {
                         "description": "Invalid proposal ID or request data",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to update proposal",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/fulfill": {
+        "/api/v1/admin/proposals/fulfill": {
             "get": {
                 "security": [
                     {
@@ -2235,9 +2346,6 @@
                     }
                 ],
                 "description": "Marks multiple proposals as fulfilled for a specific branch",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2265,32 +2373,25 @@
                     "200": {
                         "description": "Fulfillment result",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid branch or no valid IDs provided",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to fulfill proposals",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/image": {
+        "/api/v1/admin/proposals/image": {
             "get": {
                 "security": [
                     {
@@ -2298,9 +2399,6 @@
                     }
                 ],
                 "description": "Retrieves the image upload page for a specific proposal record",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "text/html"
                 ],
@@ -2327,19 +2425,13 @@
                     "400": {
                         "description": "Invalid proposal ID",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Proposal not found",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -2387,34 +2479,25 @@
                     "400": {
                         "description": "Invalid proposal ID or no file uploaded",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Proposal not found",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to save file or update proposal",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/images": {
+        "/api/v1/admin/proposals/images": {
             "get": {
                 "security": [
                     {
@@ -2422,9 +2505,6 @@
                     }
                 ],
                 "description": "Retrieves an image file by its name",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/octet-stream"
                 ],
@@ -2451,16 +2531,13 @@
                     "404": {
                         "description": "Image not found",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/new": {
+        "/api/v1/admin/proposals/new": {
             "post": {
                 "security": [
                     {
@@ -2503,32 +2580,25 @@
                     "200": {
                         "description": "Proposals created successfully",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid branch or request body",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Failed to create proposals",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/proposals/pdf/pdf": {
+        "/api/v1/admin/proposals/pdf/pdf": {
             "get": {
                 "security": [
                     {
@@ -2536,9 +2606,6 @@
                     }
                 ],
                 "description": "Generates a PDF document with unfulfilled proposals",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2550,124 +2617,19 @@
                     "200": {
                         "description": "PDF generation result with proposals data",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "500": {
                         "description": "Failed to fetch or decode proposals",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/sales/transactions/{branch_id}": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Create a new sales transaction for a branch",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "sales/transactions"
-                ],
-                "summary": "Create a new sales transaction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Branch ID",
-                        "name": "branch_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Transaction details",
-                        "name": "transaction",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.TransactionBase"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/sales/transactions/{transaction_id}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a sales transaction by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "sales/transactions"
-                ],
-                "summary": "Delete a sales transaction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Transaction ID",
-                        "name": "transaction_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/models.Output"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/suppliers": {
+        "/api/v1/admin/suppliers": {
             "get": {
                 "security": [
                     {
@@ -2733,13 +2695,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-array_models_Supplier"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -2776,31 +2738,31 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Supplier"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/suppliers/{branch_id}/{supplier_id}/transactions": {
+        "/api/v1/admin/suppliers/{branch_id}/{supplier_id}/transactions": {
             "post": {
                 "security": [
                     {
@@ -2848,25 +2810,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Transaction"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/suppliers/{id}": {
+        "/api/v1/admin/suppliers/{id}": {
             "get": {
                 "security": [
                     {
@@ -2897,19 +2859,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.Output-models_Supplier"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -2953,25 +2915,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -3006,25 +2968,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.MessageResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/models.Output"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/api/transactions/branch/{branch_id}": {
+        "/api/v1/admin/transactions/branch/{branch_id}": {
             "get": {
                 "security": [
                     {
@@ -3133,7 +3095,7 @@
                 }
             }
         },
-        "/api/transactions/docs/initiator_type": {
+        "/api/v1/admin/transactions/docs/initiator_type": {
             "get": {
                 "security": [
                     {
@@ -3164,7 +3126,7 @@
                 }
             }
         },
-        "/api/transactions/docs/payment_method": {
+        "/api/v1/admin/transactions/docs/payment_method": {
             "get": {
                 "security": [
                     {
@@ -3195,7 +3157,7 @@
                 }
             }
         },
-        "/api/transactions/docs/type": {
+        "/api/v1/admin/transactions/docs/type": {
             "get": {
                 "security": [
                     {
@@ -3226,7 +3188,7 @@
                 }
             }
         },
-        "/api/transactions/{id}": {
+        "/api/v1/admin/transactions/{id}": {
             "put": {
                 "security": [
                     {
@@ -3334,7 +3296,7 @@
                 }
             }
         },
-        "/api/transactions/{transaction_id}": {
+        "/api/v1/admin/transactions/{transaction_id}": {
             "get": {
                 "security": [
                     {
@@ -3377,58 +3339,152 @@
                 }
             }
         },
-        "/auth/login": {
-            "post": {
-                "description": "Authenticate user and return a token",
-                "consumes": [
-                    "application/json"
+        "/api/v1/store/account/addresses": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
                 ],
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "auth"
+                    "store-account"
                 ],
-                "summary": "Login a user",
-                "parameters": [
-                    {
-                        "description": "User credentials",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
+                "summary": "List the customer's saved addresses",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
-                            "$ref": "#/definitions/auth.LoginInput"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
                 ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-account"
+                ],
+                "summary": "Add a new address to the customer's address book",
                 "responses": {
-                    "200": {
-                        "description": "token",
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
             }
         },
-        "/auth/register": {
+        "/api/v1/store/account/addresses/{address_id}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-account"
+                ],
+                "summary": "Update an address",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Address ID",
+                        "name": "address_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-account"
+                ],
+                "summary": "Delete an address",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Address ID",
+                        "name": "address_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/account/addresses/{address_id}/default": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-account"
+                ],
+                "summary": "Mark an address as the default",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Address ID",
+                        "name": "address_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/login": {
             "post": {
-                "description": "Create a new user account",
+                "description": "Authenticate a storefront customer and return a token",
                 "consumes": [
                     "application/json"
                 ],
@@ -3436,31 +3492,1183 @@
                     "application/json"
                 ],
                 "tags": [
-                    "auth"
+                    "store-auth"
                 ],
-                "summary": "Register a new user",
+                "summary": "Login a storefront customer",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/logout": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Logout the current storefront customer",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/me": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Get current storefront customer profile",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Update current storefront customer profile",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/password/forgot": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Request a password reset",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/password/reset": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Reset a password with a reset token",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/refresh": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Refresh a storefront access token",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/auth/register": {
+            "post": {
+                "description": "Create a new storefront customer account",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-auth"
+                ],
+                "summary": "Register a storefront customer",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/cart": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Get the current customer's cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Empty the cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/cart/items": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Add an item to the cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/cart/items/{item_id}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Update a cart item's quantity",
                 "parameters": [
                     {
-                        "description": "User credentials",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.User"
-                        }
+                        "type": "string",
+                        "description": "Cart item ID",
+                        "name": "item_id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
-                    "201": {
-                        "description": "Created",
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Remove an item from the cart",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cart item ID",
+                        "name": "item_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/cart/promo": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Apply a coupon code to the cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-cart"
+                ],
+                "summary": "Remove the applied coupon from the cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/catalog/brands": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-catalog"
+                ],
+                "summary": "List brands / manufacturers",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/catalog/categories": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-catalog"
+                ],
+                "summary": "List catalog categories",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/catalog/categories/{id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-catalog"
+                ],
+                "summary": "Get a category by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Category ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/catalog/categories/{id}/products": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-catalog"
+                ],
+                "summary": "List products in a category",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Category ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/catalog/search": {
+            "get": {
+                "description": "Full-text search with filters, facets, sort and pagination",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-catalog"
+                ],
+                "summary": "Search the catalog",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/checkout/preview": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Preview checkout totals (items, shipping, tax) before placing an order",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/orders": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "List the customer's orders",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Place an order from the current cart",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/orders/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Get an order by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/orders/{id}/cancel": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Cancel an order",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/orders/{id}/reorder": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Re-add the items of a past order to the cart",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/orders/{id}/status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-orders"
+                ],
+                "summary": "Get an order's status / tracking",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products": {
+            "get": {
+                "description": "List products with filter/sort/pagination",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "List storefront products",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page",
+                        "name": "count",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products/{id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "Get a storefront product by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products/{id}/availability": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "Get a product's stock availability per branch",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products/{id}/images": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "Get a product's images",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products/{id}/related": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "Get related / recommended products",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/products/{id}/reviews": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-products"
+                ],
+                "summary": "List reviews for a product (public)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-reviews"
+                ],
+                "summary": "Create a review for a product",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/promotions": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-promotions"
+                ],
+                "summary": "List active promotions / banners",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/promotions/coupons/{code}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-promotions"
+                ],
+                "summary": "Look up a coupon's terms by code",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Coupon code",
+                        "name": "code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/promotions/validate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-promotions"
+                ],
+                "summary": "Validate a coupon against the current cart / customer",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/promotions/{id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-promotions"
+                ],
+                "summary": "Get a promotion by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Promotion ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/reviews/{id}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-reviews"
+                ],
+                "summary": "Update the caller's own review",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-reviews"
+                ],
+                "summary": "Delete the caller's own review",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/reviews/{id}/vote": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-reviews"
+                ],
+                "summary": "Vote a review helpful / unhelpful",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/wishlist": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-wishlist"
+                ],
+                "summary": "Get the current customer's wishlist",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/wishlist/items": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-wishlist"
+                ],
+                "summary": "Add a product to the wishlist",
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/wishlist/items/{product_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-wishlist"
+                ],
+                "summary": "Remove a product from the wishlist",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "product_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/store/wishlist/items/{product_id}/move-to-cart": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store-wishlist"
+                ],
+                "summary": "Move a wishlist product into the cart",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Product ID",
+                        "name": "product_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorOutput"
                         }
                     }
                 }
@@ -3551,6 +4759,90 @@
                 }
             }
         },
+        "middleware.Activity": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "$ref": "#/definitions/middleware.ActivityType"
+                },
+                "data": {},
+                "date": {
+                    "type": "string"
+                },
+                "ip": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "integer"
+                },
+                "userID": {
+                    "type": "string"
+                }
+            }
+        },
+        "middleware.ActivityType": {
+            "type": "string",
+            "enum": [
+                "login_success",
+                "login_failed",
+                "logout_success",
+                "logout_failed",
+                "register_success",
+                "register_failed",
+                "create_transaction",
+                "create_journal",
+                "close_journal",
+                "create_supplier",
+                "create_product",
+                "edit_transaction",
+                "edit_supplier",
+                "edit_product",
+                "delete_transaction",
+                "reopen_journal",
+                "delete_supplier",
+                "delete_product",
+                "close_sales_session",
+                "open_sales_session",
+                "product_income",
+                "product_transfer",
+                "create_operation",
+                "edit_operation",
+                "delete_operation",
+                "create_finance",
+                "edit_finance",
+                "delete_finance"
+            ],
+            "x-enum-varnames": [
+                "ActivityTypeLogin",
+                "ActivityTypeLoginFailed",
+                "ActivityTypeLogout",
+                "ActivityTypeLogoutFailed",
+                "ActivityTypeRegister",
+                "ActivityTypeRegisterFailed",
+                "ActivityTypeCreateTransaction",
+                "ActivityTypeCreateJournal",
+                "ActivityTypeCloseJournal",
+                "ActivityTypeCreateSupplier",
+                "ActivityTypeCreateProduct",
+                "ActivityTypeEditTransaction",
+                "ActivityTypeEditSupplier",
+                "ActivityTypeEditProduct",
+                "ActivityTypeDeleteTransaction",
+                "ActivityTypeReopenJournal",
+                "ActivityTypeDeleteSupplier",
+                "ActivityTypeDeleteProduct",
+                "ActivityTypeCloseSalesSession",
+                "ActivityTypeOpenSalesSession",
+                "ActivityTypeProductIncome",
+                "ActivityTypeProductTransfer",
+                "ActivityTypeCreateOperation",
+                "ActivityTypeEditOperation",
+                "ActivityTypeDeleteOperation",
+                "ActivityTypeCreateFinance",
+                "ActivityTypeEditFinance",
+                "ActivityTypeDeleteFinance"
+            ]
+        },
         "models.BNPL": {
             "type": "object",
             "properties": {
@@ -3612,6 +4904,23 @@
                 "BNPLStatusCancelled"
             ]
         },
+        "models.Balance": {
+            "type": "object",
+            "properties": {
+                "bank": {
+                    "type": "integer"
+                },
+                "cash": {
+                    "type": "integer"
+                },
+                "mobile_apps": {
+                    "type": "integer"
+                },
+                "terminal": {
+                    "type": "integer"
+                }
+            }
+        },
         "models.Branch": {
             "type": "object",
             "properties": {
@@ -3629,6 +4938,36 @@
                 }
             }
         },
+        "models.BranchFinance": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "$ref": "#/definitions/models.Balance"
+                },
+                "branch_id": {
+                    "type": "string"
+                },
+                "branch_name": {
+                    "type": "string"
+                },
+                "debt": {
+                    "type": "integer"
+                },
+                "details": {},
+                "suppliers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "total_expenses": {
+                    "type": "integer"
+                },
+                "total_income": {
+                    "type": "integer"
+                }
+            }
+        },
         "models.CloseJournalEntryInput": {
             "type": "object",
             "properties": {
@@ -3637,6 +4976,49 @@
                 },
                 "terminal_income": {
                     "type": "integer"
+                }
+            }
+        },
+        "models.Customer": {
+            "type": "object",
+            "properties": {
+                "additional_info": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "address": {
+                    "description": "Email   string `json:\"email\" bson:\"email\"`",
+                    "type": "string"
+                },
+                "bnpls": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.BNPL"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "purchase_history": {
+                    "description": "purchase history is updated when a customer a sales session or completes a BNPL session",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.SalesSession"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },
@@ -3661,6 +5043,43 @@
                 }
             }
         },
+        "models.CustomerQueryOutput": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CustomerQueryOutputData"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.CustomerQueryOutputData": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "customers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Customer"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
         "models.Error": {
             "type": "object",
             "properties": {
@@ -3669,6 +5088,70 @@
                 },
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "models.ErrorOutput": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {}
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.FinancialData": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "type": "integer"
+                },
+                "total_expenses": {
+                    "type": "integer"
+                },
+                "total_income": {
+                    "type": "integer"
+                },
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Transaction"
+                    }
+                }
+            }
+        },
+        "models.IncomeHistory": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "description": "Date of the income",
+                    "type": "string"
+                },
+                "price": {
+                    "description": "Price of the product that was uploaded",
+                    "type": "integer"
+                },
+                "quantity": {
+                    "description": "Quantity of the product that was uploaded",
+                    "type": "integer"
+                },
+                "supplier_id": {
+                    "description": "Supplier ID",
+                    "type": "string"
+                },
+                "uploaded_to": {
+                    "description": "Place where the product was uploaded to",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.ProductPlace"
+                        }
+                    ]
                 }
             }
         },
@@ -3751,6 +5234,38 @@
                 }
             }
         },
+        "models.JournalWithTransactionID": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "$ref": "#/definitions/models.Branch"
+                },
+                "cash_left": {
+                    "type": "integer"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "shift_is_closed": {
+                    "type": "boolean"
+                },
+                "terminal_income": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
         "models.ManufacturerInfo": {
             "type": "object",
             "properties": {
@@ -3772,6 +5287,14 @@
                 },
                 "phone": {
                     "description": "Contact phone number",
+                    "type": "string"
+                }
+            }
+        },
+        "models.MessageResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
                     "type": "string"
                 }
             }
@@ -3819,10 +5342,201 @@
                 }
             }
         },
-        "models.Output": {
+        "models.Output-array_middleware_Activity": {
             "type": "object",
             "properties": {
-                "data": {},
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/middleware.Activity"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_BNPL": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.BNPL"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_BranchFinance": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.BranchFinance"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_Customer": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Customer"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_Journal": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Journal"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_Product": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Product"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-array_models_Supplier": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Supplier"
+                    }
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_BNPL": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.BNPL"
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_BranchFinance": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.BranchFinance"
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_Journal": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.Journal"
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_JournalWithTransactionID": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.JournalWithTransactionID"
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_Supplier": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.Supplier"
+                },
+                "error": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Error"
+                    }
+                }
+            }
+        },
+        "models.Output-models_Transaction": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.Transaction"
+                },
                 "error": {
                     "type": "array",
                     "items": {
@@ -3851,6 +5565,79 @@
                 "OnlineTransfer",
                 "PaymentMethodUndefined"
             ]
+        },
+        "models.Product": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "description": "Product categories",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "description": "Creation timestamp",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Product description",
+                    "type": "string"
+                },
+                "general_income_price": {
+                    "description": "General income price of the product --- the price generally this item is bought from supplier",
+                    "type": "number"
+                },
+                "id": {
+                    "description": "Unique product identifier",
+                    "type": "string"
+                },
+                "images": {
+                    "description": "Product images (lins) saved to some S3",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "income_history": {
+                    "description": "Income history",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.IncomeHistory"
+                    }
+                },
+                "manufacturer": {
+                    "description": "Manufacturer details",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.ManufacturerInfo"
+                        }
+                    ]
+                },
+                "minimum_stock_alert": {
+                    "description": "Minimum stock alert",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "Product name",
+                    "type": "string"
+                },
+                "quantity_distribution": {
+                    "description": "Stock levels by location",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ProductDistribution"
+                    }
+                },
+                "sku": {
+                    "description": "Stock Keeping Unit",
+                    "type": "string"
+                },
+                "updated_at": {
+                    "description": "Last update timestamp",
+                    "type": "string"
+                }
+            }
         },
         "models.ProductBase": {
             "type": "object",
@@ -3892,6 +5679,31 @@
                 }
             }
         },
+        "models.ProductDistribution": {
+            "type": "object",
+            "properties": {
+                "place": {
+                    "description": "Location details",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.ProductPlace"
+                        }
+                    ]
+                },
+                "price": {
+                    "description": "Price of the product",
+                    "type": "integer"
+                },
+                "quantity": {
+                    "description": "Quantity of the product",
+                    "type": "integer"
+                },
+                "unit": {
+                    "description": "Unit of measurement (e.g. kg, pieces, etc)",
+                    "type": "string"
+                }
+            }
+        },
         "models.ProductPlace": {
             "type": "object",
             "properties": {
@@ -3924,6 +5736,50 @@
                 "ProductPlaceTypeWarehouse"
             ]
         },
+        "models.ProductProposal": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "fulfilled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "image_file": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.SalesSession": {
+            "type": "object",
+            "properties": {
+                "branch_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "product_items": {
+                    "description": "product which are going to be sold",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/models.SalesSessionItem"
+                    }
+                }
+            }
+        },
         "models.SalesSessionItem": {
             "type": "object",
             "properties": {
@@ -3932,6 +5788,44 @@
                 },
                 "quantity": {
                     "type": "integer"
+                }
+            }
+        },
+        "models.Supplier": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "branch": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "financial_data": {
+                    "$ref": "#/definitions/models.FinancialData"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "inn": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },
@@ -3957,6 +5851,32 @@
                     "type": "string"
                 },
                 "phone": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TokenResponse": {
+            "type": "object",
+            "properties": {
+                "aud": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "string"
+                },
+                "exp": {
+                    "type": "string"
+                },
+                "iat": {
+                    "type": "string"
+                },
+                "jti": {
+                    "type": "string"
+                },
+                "nbf": {
+                    "type": "string"
+                },
+                "sub": {
                     "type": "string"
                 }
             }
@@ -4053,16 +5973,13 @@
                 "TransactionTypeDebit"
             ]
         },
-        "models.User": {
+        "models.UserRegisterInput": {
             "type": "object",
             "properties": {
                 "branch": {
                     "type": "string"
                 },
                 "email": {
-                    "type": "string"
-                },
-                "id": {
                     "type": "string"
                 },
                 "password": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -18,6 +18,80 @@ definitions:
     - password
     - username
     type: object
+  middleware.Activity:
+    properties:
+      action:
+        $ref: '#/definitions/middleware.ActivityType'
+      data: {}
+      date:
+        type: string
+      ip:
+        type: string
+      status:
+        type: integer
+      userID:
+        type: string
+    type: object
+  middleware.ActivityType:
+    enum:
+    - login_success
+    - login_failed
+    - logout_success
+    - logout_failed
+    - register_success
+    - register_failed
+    - create_transaction
+    - create_journal
+    - close_journal
+    - create_supplier
+    - create_product
+    - edit_transaction
+    - edit_supplier
+    - edit_product
+    - delete_transaction
+    - reopen_journal
+    - delete_supplier
+    - delete_product
+    - close_sales_session
+    - open_sales_session
+    - product_income
+    - product_transfer
+    - create_operation
+    - edit_operation
+    - delete_operation
+    - create_finance
+    - edit_finance
+    - delete_finance
+    type: string
+    x-enum-varnames:
+    - ActivityTypeLogin
+    - ActivityTypeLoginFailed
+    - ActivityTypeLogout
+    - ActivityTypeLogoutFailed
+    - ActivityTypeRegister
+    - ActivityTypeRegisterFailed
+    - ActivityTypeCreateTransaction
+    - ActivityTypeCreateJournal
+    - ActivityTypeCloseJournal
+    - ActivityTypeCreateSupplier
+    - ActivityTypeCreateProduct
+    - ActivityTypeEditTransaction
+    - ActivityTypeEditSupplier
+    - ActivityTypeEditProduct
+    - ActivityTypeDeleteTransaction
+    - ActivityTypeReopenJournal
+    - ActivityTypeDeleteSupplier
+    - ActivityTypeDeleteProduct
+    - ActivityTypeCloseSalesSession
+    - ActivityTypeOpenSalesSession
+    - ActivityTypeProductIncome
+    - ActivityTypeProductTransfer
+    - ActivityTypeCreateOperation
+    - ActivityTypeEditOperation
+    - ActivityTypeDeleteOperation
+    - ActivityTypeCreateFinance
+    - ActivityTypeEditFinance
+    - ActivityTypeDeleteFinance
   models.BNPL:
     properties:
       branch_id:
@@ -59,6 +133,17 @@ definitions:
     - BNPLStatusActive
     - BNPLStatusCompleted
     - BNPLStatusCancelled
+  models.Balance:
+    properties:
+      bank:
+        type: integer
+      cash:
+        type: integer
+      mobile_apps:
+        type: integer
+      terminal:
+        type: integer
+    type: object
   models.Branch:
     properties:
       id:
@@ -70,12 +155,62 @@ definitions:
       phone:
         type: string
     type: object
+  models.BranchFinance:
+    properties:
+      balance:
+        $ref: '#/definitions/models.Balance'
+      branch_id:
+        type: string
+      branch_name:
+        type: string
+      debt:
+        type: integer
+      details: {}
+      suppliers:
+        items:
+          type: string
+        type: array
+      total_expenses:
+        type: integer
+      total_income:
+        type: integer
+    type: object
   models.CloseJournalEntryInput:
     properties:
       cash_left:
         type: integer
       terminal_income:
         type: integer
+    type: object
+  models.Customer:
+    properties:
+      additional_info:
+        additionalProperties:
+          type: string
+        type: object
+      address:
+        description: Email   string `json:"email" bson:"email"`
+        type: string
+      bnpls:
+        items:
+          $ref: '#/definitions/models.BNPL'
+        type: array
+      created_at:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      phone:
+        type: string
+      purchase_history:
+        description: purchase history is updated when a customer a sales session or
+          completes a BNPL session
+        items:
+          $ref: '#/definitions/models.SalesSession'
+        type: array
+      updated_at:
+        type: string
     type: object
   models.CustomerBase:
     properties:
@@ -91,12 +226,78 @@ definitions:
       phone:
         type: string
     type: object
+  models.CustomerQueryOutput:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/models.CustomerQueryOutputData'
+        type: array
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.CustomerQueryOutputData:
+    properties:
+      count:
+        type: integer
+      customers:
+        items:
+          $ref: '#/definitions/models.Customer'
+        type: array
+      page:
+        type: integer
+      total:
+        type: integer
+    type: object
   models.Error:
     properties:
       code:
         type: integer
       message:
         type: string
+    type: object
+  models.ErrorOutput:
+    properties:
+      data:
+        items: {}
+        type: array
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.FinancialData:
+    properties:
+      balance:
+        type: integer
+      total_expenses:
+        type: integer
+      total_income:
+        type: integer
+      transactions:
+        items:
+          $ref: '#/definitions/models.Transaction'
+        type: array
+    type: object
+  models.IncomeHistory:
+    properties:
+      date:
+        description: Date of the income
+        type: string
+      price:
+        description: Price of the product that was uploaded
+        type: integer
+      quantity:
+        description: Quantity of the product that was uploaded
+        type: integer
+      supplier_id:
+        description: Supplier ID
+        type: string
+      uploaded_to:
+        allOf:
+        - $ref: '#/definitions/models.ProductPlace'
+        description: Place where the product was uploaded to
     type: object
   models.InitiatorType:
     enum:
@@ -154,6 +355,27 @@ definitions:
       type:
         $ref: '#/definitions/models.TransactionType'
     type: object
+  models.JournalWithTransactionID:
+    properties:
+      branch:
+        $ref: '#/definitions/models.Branch'
+      cash_left:
+        type: integer
+      date:
+        type: string
+      id:
+        type: string
+      operations:
+        items:
+          type: string
+        type: array
+      shift_is_closed:
+        type: boolean
+      terminal_income:
+        type: integer
+      total:
+        type: integer
+    type: object
   models.ManufacturerInfo:
     properties:
       address:
@@ -170,6 +392,11 @@ definitions:
         type: string
       phone:
         description: Contact phone number
+        type: string
+    type: object
+  models.MessageResponse:
+    properties:
+      message:
         type: string
     type: object
   models.NewBNPLInput:
@@ -200,9 +427,132 @@ definitions:
       date:
         type: string
     type: object
-  models.Output:
+  models.Output-array_middleware_Activity:
     properties:
-      data: {}
+      data:
+        items:
+          $ref: '#/definitions/middleware.Activity'
+        type: array
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-array_models_BNPL:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/models.BNPL'
+        type: array
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-array_models_BranchFinance:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/models.BranchFinance'
+        type: array
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-array_models_Customer:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/models.Customer'
+        type: array
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-array_models_Journal:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/models.Journal'
+        type: array
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-array_models_Product:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/models.Product'
+        type: array
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-array_models_Supplier:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/models.Supplier'
+        type: array
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-models_BNPL:
+    properties:
+      data:
+        $ref: '#/definitions/models.BNPL'
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-models_BranchFinance:
+    properties:
+      data:
+        $ref: '#/definitions/models.BranchFinance'
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-models_Journal:
+    properties:
+      data:
+        $ref: '#/definitions/models.Journal'
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-models_JournalWithTransactionID:
+    properties:
+      data:
+        $ref: '#/definitions/models.JournalWithTransactionID'
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-models_Supplier:
+    properties:
+      data:
+        $ref: '#/definitions/models.Supplier'
+      error:
+        items:
+          $ref: '#/definitions/models.Error'
+        type: array
+    type: object
+  models.Output-models_Transaction:
+    properties:
+      data:
+        $ref: '#/definitions/models.Transaction'
       error:
         items:
           $ref: '#/definitions/models.Error'
@@ -226,6 +576,58 @@ definitions:
     - Cheque
     - OnlineTransfer
     - PaymentMethodUndefined
+  models.Product:
+    properties:
+      category:
+        description: Product categories
+        items:
+          type: string
+        type: array
+      created_at:
+        description: Creation timestamp
+        type: string
+      description:
+        description: Product description
+        type: string
+      general_income_price:
+        description: General income price of the product --- the price generally this
+          item is bought from supplier
+        type: number
+      id:
+        description: Unique product identifier
+        type: string
+      images:
+        description: Product images (lins) saved to some S3
+        items:
+          type: string
+        type: array
+      income_history:
+        description: Income history
+        items:
+          $ref: '#/definitions/models.IncomeHistory'
+        type: array
+      manufacturer:
+        allOf:
+        - $ref: '#/definitions/models.ManufacturerInfo'
+        description: Manufacturer details
+      minimum_stock_alert:
+        description: Minimum stock alert
+        type: integer
+      name:
+        description: Product name
+        type: string
+      quantity_distribution:
+        description: Stock levels by location
+        items:
+          $ref: '#/definitions/models.ProductDistribution'
+        type: array
+      sku:
+        description: Stock Keeping Unit
+        type: string
+      updated_at:
+        description: Last update timestamp
+        type: string
+    type: object
   models.ProductBase:
     properties:
       category:
@@ -254,6 +656,22 @@ definitions:
         description: Stock Keeping Unit
         type: string
     type: object
+  models.ProductDistribution:
+    properties:
+      place:
+        allOf:
+        - $ref: '#/definitions/models.ProductPlace'
+        description: Location details
+      price:
+        description: Price of the product
+        type: integer
+      quantity:
+        description: Quantity of the product
+        type: integer
+      unit:
+        description: Unit of measurement (e.g. kg, pieces, etc)
+        type: string
+    type: object
   models.ProductPlace:
     properties:
       id:
@@ -275,12 +693,66 @@ definitions:
     x-enum-varnames:
     - ProductPlaceTypeBranch
     - ProductPlaceTypeWarehouse
+  models.ProductProposal:
+    properties:
+      branch:
+        type: string
+      date:
+        type: string
+      fulfilled:
+        type: boolean
+      id:
+        type: string
+      image_file:
+        type: string
+      name:
+        type: string
+    type: object
+  models.SalesSession:
+    properties:
+      branch_id:
+        type: string
+      created_at:
+        type: string
+      id:
+        type: string
+      product_items:
+        additionalProperties:
+          $ref: '#/definitions/models.SalesSessionItem'
+        description: product which are going to be sold
+        type: object
+    type: object
   models.SalesSessionItem:
     properties:
       price:
         type: integer
       quantity:
         type: integer
+    type: object
+  models.Supplier:
+    properties:
+      address:
+        type: string
+      branch:
+        type: string
+      created_at:
+        type: string
+      email:
+        type: string
+      financial_data:
+        $ref: '#/definitions/models.FinancialData'
+      id:
+        type: string
+      inn:
+        type: string
+      name:
+        type: string
+      notes:
+        type: string
+      phone:
+        type: string
+      updated_at:
+        type: string
     type: object
   models.SupplierBase:
     properties:
@@ -297,6 +769,23 @@ definitions:
       notes:
         type: string
       phone:
+        type: string
+    type: object
+  models.TokenResponse:
+    properties:
+      aud:
+        type: string
+      data:
+        type: string
+      exp:
+        type: string
+      iat:
+        type: string
+      jti:
+        type: string
+      nbf:
+        type: string
+      sub:
         type: string
     type: object
   models.Transaction:
@@ -362,13 +851,11 @@ definitions:
     x-enum-varnames:
     - TransactionTypeCredit
     - TransactionTypeDebit
-  models.User:
+  models.UserRegisterInput:
     properties:
       branch:
         type: string
       email:
-        type: string
-      id:
         type: string
       password:
         type: string
@@ -413,10 +900,72 @@ info:
   title: G4H ERP/POS API
   version: "1.0"
 paths:
-  /api/activities/me:
-    get:
+  /api/sales/transactions/{branch_id}:
+    post:
       consumes:
       - application/json
+      description: Create a new sales transaction for a branch
+      parameters:
+      - description: Branch ID
+        in: path
+        name: branch_id
+        required: true
+        type: string
+      - description: Transaction details
+        in: body
+        name: transaction
+        required: true
+        schema:
+          $ref: '#/definitions/models.TransactionBase'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.Output-models_Transaction'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Create a new sales transaction
+      tags:
+      - sales/transactions
+  /api/sales/transactions/{transaction_id}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a sales transaction by ID
+      parameters:
+      - description: Transaction ID
+        in: path
+        name: transaction_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Output-models_Transaction'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Delete a sales transaction
+      tags:
+      - sales/transactions
+  /api/v1/admin/activities/me:
+    get:
       description: Get the 25 most recent activities for the authenticated user
       produces:
       - application/json
@@ -424,20 +973,18 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_middleware_Activity'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get activities of current user
       tags:
       - auth
-  /api/activities/recent:
+  /api/v1/admin/activities/recent:
     get:
-      consumes:
-      - application/json
       description: Get the 25 most recent activities across all users
       produces:
       - application/json
@@ -445,20 +992,48 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_middleware_Activity'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get recent activities
       tags:
       - auth
-  /api/auth/me:
-    get:
+  /api/v1/admin/auth/login:
+    post:
       consumes:
       - application/json
+      description: Authenticate user and return a token
+      parameters:
+      - description: User credentials
+        in: body
+        name: user
+        required: true
+        schema:
+          $ref: '#/definitions/auth.LoginInput'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: token
+          schema:
+            $ref: '#/definitions/models.TokenResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Login a user
+      tags:
+      - auth
+  /api/v1/admin/auth/me:
+    get:
       description: Get user info
       produces:
       - application/json
@@ -466,19 +1041,17 @@ paths:
         "200":
           description: message
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.MessageResponse'
         "500":
           description: Internal Server Error
           schema:
-            type: string
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get user info
       tags:
       - auth
-  /api/bnpl:
+  /api/v1/admin/bnpl:
     post:
       consumes:
       - application/json
@@ -496,24 +1069,22 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_BNPL'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Create new BNPL
       tags:
       - BNPL
-  /api/bnpl/{id}:
+  /api/v1/admin/bnpl/{id}:
     delete:
-      consumes:
-      - application/json
       description: Delete an existing BNPL transaction
       parameters:
       - description: BNPL ID
@@ -527,21 +1098,17 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.MessageResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Delete BNPL
       tags:
       - BNPL
     get:
-      consumes:
-      - application/json
       description: Get details of a specific BNPL transaction
       parameters:
       - description: BNPL ID
@@ -555,17 +1122,17 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-models_BNPL'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get BNPL details
       tags:
       - BNPL
-  /api/bnpl/{id}/credit:
+  /api/v1/admin/bnpl/{id}/credit:
     post:
       consumes:
       - application/json
@@ -592,20 +1159,18 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.BNPL'
+            $ref: '#/definitions/models.Output-array_models_BNPL'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Credit BNPL payment
       tags:
       - BNPL
-  /api/branches/{branch_id}/bnpls:
+  /api/v1/admin/branches/{branch_id}/bnpls:
     get:
-      consumes:
-      - application/json
       description: Get all BNPL transactions for a specific branch
       parameters:
       - description: Branch ID
@@ -631,17 +1196,17 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_Customer'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get BNPLs of branch
       tags:
       - BNPL
-  /api/customers:
+  /api/v1/admin/customers:
     get:
       consumes:
       - application/json
@@ -677,11 +1242,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.CustomerQueryOutput'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get all customers
@@ -704,24 +1273,26 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_Customer'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Create a new customer
       tags:
       - customers
-  /api/customers/{customer_id}/bnpls:
+  /api/v1/admin/customers/{customer_id}/bnpls:
     get:
-      consumes:
-      - application/json
       description: Get all BNPL transactions for a specific customer
       parameters:
       - description: Customer ID
@@ -739,20 +1310,18 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_BNPL'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get customer BNPLs
       tags:
       - BNPL
-  /api/customers/{id}:
+  /api/v1/admin/customers/{id}:
     delete:
-      consumes:
-      - application/json
       description: Delete a customer from the database
       parameters:
       - description: Customer ID
@@ -766,23 +1335,25 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.MessageResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Delete a customer
       tags:
       - customers
     get:
-      consumes:
-      - application/json
       description: Get a customer by its ID
       parameters:
       - description: Customer ID
@@ -796,15 +1367,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_Customer'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get a customer by ID
@@ -832,25 +1403,29 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_Customer'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Update a customer
       tags:
       - customers
-  /api/finance:
+  /api/v1/admin/finance:
     post:
       consumes:
       - application/json
@@ -868,21 +1443,21 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-models_BranchFinance'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Create new finance for a branch
       tags:
       - finance
-  /api/finance/branch/id/{id}:
+  /api/v1/admin/finance/branch/id/{id}:
     get:
       description: Retrieve a branch using its ID
       parameters:
@@ -897,17 +1472,17 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-models_BranchFinance'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Fetch branch by ID
       tags:
       - finance
-  /api/finance/branch/name/{branch_name}:
+  /api/v1/admin/finance/branch/name/{branch_name}:
     get:
       description: Retrieve finance details using the branch name
       parameters:
@@ -922,17 +1497,17 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-models_BranchFinance'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Fetch finance by branch name
       tags:
       - finance
-  /api/finance/branches:
+  /api/v1/admin/finance/branches:
     get:
       description: Retrieve all branches from the finance collection
       produces:
@@ -941,17 +1516,17 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_BranchFinance'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Fetch all branches
       tags:
       - finance
-  /api/finance/id/{id}:
+  /api/v1/admin/finance/id/{id}:
     get:
       description: Retrieve finance details using its ID --- ObjectID not branch_id
       parameters:
@@ -966,17 +1541,21 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-models_BranchFinance'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Fetch finance by ID
       tags:
       - finance
-  /api/journals:
+  /api/v1/admin/journals:
     post:
       consumes:
       - application/json
@@ -994,24 +1573,22 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Journal'
+            $ref: '#/definitions/models.Output-models_JournalWithTransactionID'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Create a new journal entry
       tags:
       - journals
-  /api/journals/{journal_id}:
+  /api/v1/admin/journals/{journal_id}:
     get:
-      consumes:
-      - application/json
       description: Get a journal entry by its ID
       parameters:
       - description: Journal ID
@@ -1025,17 +1602,17 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Journal'
+            $ref: '#/definitions/models.Output-models_Journal'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get a journal entry by ID
       tags:
       - journals
-  /api/journals/{journal_id}/close:
+  /api/v1/admin/journals/{journal_id}/close:
     post:
       consumes:
       - application/json
@@ -1055,26 +1632,24 @@ paths:
       produces:
       - application/json
       responses:
-        "201":
-          description: Created
+        "200":
+          description: OK
           schema:
-            items:
-              $ref: '#/definitions/models.Transaction'
-            type: array
+            $ref: '#/definitions/models.Output-models_Journal'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Close a journal entry
       tags:
       - journals
-  /api/journals/{journal_id}/operations:
+  /api/v1/admin/journals/{journal_id}/operations:
     post:
       consumes:
       - application/json
@@ -1094,27 +1669,25 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
+        "201":
+          description: Created
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-models_Journal'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Create a new operation transaction
       tags:
       - journals/operations
-  /api/journals/{journal_id}/operations/{id}:
+  /api/v1/admin/journals/{journal_id}/operations/{id}:
     delete:
-      consumes:
-      - application/json
       description: Delete an operation transaction by ID
       parameters:
       - description: Operation ID
@@ -1133,23 +1706,21 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
-        "400":
-          description: Bad Request
+            $ref: '#/definitions/models.Output-models_Journal'
+        "404":
+          description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Delete an operation transaction
       tags:
       - journals/operations
     get:
-      consumes:
-      - application/json
       description: Get an operation transaction by ID
       parameters:
       - description: Operation ID
@@ -1168,23 +1739,17 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-models_Transaction'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get an operation transaction by ID
       tags:
       - journals/operations
     put:
-      consumes:
-      - application/json
       description: Update an operation transaction by ID
       parameters:
       - description: Operation ID
@@ -1212,24 +1777,26 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-models_Journal'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Update an operation transaction
       tags:
       - journals/operations
-  /api/journals/{journal_id}/reopen:
+  /api/v1/admin/journals/{journal_id}/reopen:
     post:
-      consumes:
-      - application/json
       description: Reopen a journal entry by removing its closing transactions
       parameters:
       - description: Journal ID
@@ -1243,22 +1810,22 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/models.Transaction'
-            type: array
+            $ref: '#/definitions/models.Output-models_Journal'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Reopen a closed journal entry
       tags:
       - journals
-  /api/journals/branch/{branch_id}:
+  /api/v1/admin/journals/branch/{branch_id}:
     get:
-      consumes:
-      - application/json
       description: Query journal entries by branch ID
       parameters:
       - description: Branch ID
@@ -1280,35 +1847,41 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/models.Journal'
-            type: array
+            $ref: '#/definitions/models.Output-array_models_Journal'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Error'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Query journal entries
       tags:
       - journals
-  /api/journals/report:
+  /api/v1/admin/journals/report:
     get:
-      consumes:
-      - application/json
       description: Get a report of journal entries
       produces:
       - application/json
-      responses: {}
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.MessageResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get a report
       tags:
       - journals
-  /api/products:
+  /api/v1/admin/products:
     get:
-      consumes:
-      - application/json
       description: Query products based on various parameters
       parameters:
       - description: Branch ID
@@ -1333,15 +1906,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_Product'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Query products
@@ -1364,24 +1937,22 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_Product'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Create a new product
       tags:
       - products
-  /api/products/{id}:
+  /api/v1/admin/products/{id}:
     delete:
-      consumes:
-      - application/json
       description: Deletes a product and its related data
       parameters:
       - description: Product ID
@@ -1395,19 +1966,17 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_Product'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Delete a product
       tags:
       - products
     get:
-      consumes:
-      - application/json
       description: Retrieves a product by its ID
       parameters:
       - description: Product ID
@@ -1421,11 +1990,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_Product'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get a product by ID
@@ -1453,21 +2022,21 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_Product'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Edit a product
       tags:
       - products
-  /api/products/{id}/income:
+  /api/v1/admin/products/{id}/income:
     post:
       consumes:
       - application/json
@@ -1490,25 +2059,25 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_Product'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Add new income for a product
       tags:
       - products
-  /api/products/{product_id}/images:
+  /api/v1/admin/products/{product_id}/images:
     get:
       description: Returns a list of image URLs for a given product
       parameters:
@@ -1523,7 +2092,11 @@ paths:
         "200":
           description: OK
           schema:
-            type: string
+            additionalProperties:
+              items:
+                type: string
+              type: array
+            type: object
         "400":
           description: Bad Request
           schema:
@@ -1558,7 +2131,9 @@ paths:
         "200":
           description: OK
           schema:
-            type: string
+            additionalProperties:
+              type: string
+            type: object
         "400":
           description: Bad Request
           schema:
@@ -1572,7 +2147,7 @@ paths:
       summary: Upload a product image
       tags:
       - products
-  /api/products/{product_id}/images/{key}:
+  /api/v1/admin/products/{product_id}/images/{key}:
     delete:
       description: Deletes a product image from S3 and removes reference from database
       parameters:
@@ -1606,7 +2181,7 @@ paths:
       summary: Delete a product image
       tags:
       - products
-  /api/products/images/{key}:
+  /api/v1/admin/products/images/{key}:
     get:
       description: Returns the image file for a given image key
       parameters:
@@ -1635,23 +2210,27 @@ paths:
       summary: Get a single product image
       tags:
       - products
-  /api/products/transfer:
+  /api/v1/admin/products/transfer:
     post:
-      consumes:
-      - application/json
       description: Transfers product quantity from one location to another
       produces:
       - application/json
-      responses: {}
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Output-array_models_Product'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Transfer product between locations
       tags:
       - products
-  /api/proposals:
+  /api/v1/admin/proposals:
     get:
-      consumes:
-      - application/json
       description: Retrieves all proposals with optional filters
       parameters:
       - description: Filter by name (case-insensitive)
@@ -1682,30 +2261,23 @@ paths:
           description: List of proposals
           schema:
             items:
-              additionalProperties: true
-              type: object
+              $ref: '#/definitions/models.ProductProposal'
             type: array
         "400":
           description: Invalid date format
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Failed to fetch or decode proposals
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get all proposals
       tags:
       - proposals
-  /api/proposals/delete:
+  /api/v1/admin/proposals/delete:
     delete:
-      consumes:
-      - application/json
       description: Deletes a proposal record and its associated image file
       parameters:
       - description: Proposal ID
@@ -1723,30 +2295,22 @@ paths:
         "400":
           description: Invalid proposal ID
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
         "404":
           description: Proposal not found
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Failed to delete proposal
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Delete proposal
       tags:
       - proposals
-  /api/proposals/detail:
+  /api/v1/admin/proposals/detail:
     get:
-      consumes:
-      - application/json
       description: Retrieves detailed information for a specific proposal record
       parameters:
       - description: Proposal ID
@@ -1764,25 +2328,20 @@ paths:
         "400":
           description: Invalid proposal ID
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
         "404":
           description: Proposal not found
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get proposal detail
       tags:
       - proposals
-  /api/proposals/edit:
+  /api/v1/admin/proposals/edit:
     put:
       consumes:
       - application/json
-      - application/x-www-form-urlencoded
       description: Updates an existing proposal record
       parameters:
       - description: Proposal ID
@@ -1805,24 +2364,18 @@ paths:
         "400":
           description: Invalid proposal ID or request data
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Failed to update proposal
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Edit proposal
       tags:
       - proposals
-  /api/proposals/fulfill:
+  /api/v1/admin/proposals/fulfill:
     get:
-      consumes:
-      - application/json
       description: Marks multiple proposals as fulfilled for a specific branch
       parameters:
       - description: Branch name
@@ -1841,29 +2394,22 @@ paths:
         "200":
           description: Fulfillment result
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/models.MessageResponse'
         "400":
           description: Invalid branch or no valid IDs provided
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Failed to fulfill proposals
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Fulfill proposals
       tags:
       - proposals
-  /api/proposals/image:
+  /api/v1/admin/proposals/image:
     get:
-      consumes:
-      - application/json
       description: Retrieves the image upload page for a specific proposal record
       parameters:
       - description: Proposal ID
@@ -1881,15 +2427,11 @@ paths:
         "400":
           description: Invalid proposal ID
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
         "404":
           description: Proposal not found
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get image upload page by proposal ID
@@ -1920,30 +2462,22 @@ paths:
         "400":
           description: Invalid proposal ID or no file uploaded
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
         "404":
           description: Proposal not found
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Failed to save file or update proposal
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Upload image for proposal
       tags:
       - proposals
-  /api/proposals/images:
+  /api/v1/admin/proposals/images:
     get:
-      consumes:
-      - application/json
       description: Retrieves an image file by its name
       parameters:
       - description: Image name
@@ -1961,15 +2495,13 @@ paths:
         "404":
           description: Image not found
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get image by name
       tags:
       - proposals
-  /api/proposals/new:
+  /api/v1/admin/proposals/new:
     post:
       consumes:
       - application/json
@@ -1994,29 +2526,22 @@ paths:
         "200":
           description: Proposals created successfully
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/models.MessageResponse'
         "400":
           description: Invalid branch or request body
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Failed to create proposals
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Create new proposals
       tags:
       - proposals
-  /api/proposals/pdf/pdf:
+  /api/v1/admin/proposals/pdf/pdf:
     get:
-      consumes:
-      - application/json
       description: Generates a PDF document with unfulfilled proposals
       produces:
       - application/json
@@ -2024,84 +2549,17 @@ paths:
         "200":
           description: PDF generation result with proposals data
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/models.MessageResponse'
         "500":
           description: Failed to fetch or decode proposals
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Generate PDF
       tags:
       - proposals
-  /api/sales/transactions/{branch_id}:
-    post:
-      consumes:
-      - application/json
-      description: Create a new sales transaction for a branch
-      parameters:
-      - description: Branch ID
-        in: path
-        name: branch_id
-        required: true
-        type: string
-      - description: Transaction details
-        in: body
-        name: transaction
-        required: true
-        schema:
-          $ref: '#/definitions/models.TransactionBase'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/models.Output'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/models.Output'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/models.Output'
-      security:
-      - BearerAuth: []
-      summary: Create a new sales transaction
-      tags:
-      - sales/transactions
-  /api/sales/transactions/{transaction_id}:
-    delete:
-      consumes:
-      - application/json
-      description: Delete a sales transaction by ID
-      parameters:
-      - description: Transaction ID
-        in: path
-        name: transaction_id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/models.Output'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/models.Output'
-      security:
-      - BearerAuth: []
-      summary: Delete a sales transaction
-      tags:
-      - sales/transactions
-  /api/suppliers:
+  /api/v1/admin/suppliers:
     get:
       consumes:
       - application/json
@@ -2141,11 +2599,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-array_models_Supplier'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get all suppliers
@@ -2168,25 +2626,25 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-models_Supplier'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Create a new supplier
       tags:
       - suppliers
-  /api/suppliers/{branch_id}/{supplier_id}/transactions:
+  /api/v1/admin/suppliers/{branch_id}/{supplier_id}/transactions:
     post:
       consumes:
       - application/json
@@ -2214,22 +2672,22 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-models_Transaction'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Create a new transaction for a supplier
       tags:
       - suppliers
       - transactions
-  /api/suppliers/{id}:
+  /api/v1/admin/suppliers/{id}:
     delete:
       consumes:
       - application/json
@@ -2246,15 +2704,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.MessageResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Delete a supplier
@@ -2276,15 +2734,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.Output-models_Supplier'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Get a supplier by ID
@@ -2312,25 +2770,25 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.MessageResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/models.Output'
+            $ref: '#/definitions/models.ErrorOutput'
       security:
       - BearerAuth: []
       summary: Update a supplier
       tags:
       - suppliers
-  /api/transactions/{id}:
+  /api/v1/admin/transactions/{id}:
     delete:
       consumes:
       - application/json
@@ -2399,7 +2857,7 @@ paths:
       summary: Update a transaction by ID
       tags:
       - transactions
-  /api/transactions/{transaction_id}:
+  /api/v1/admin/transactions/{transaction_id}:
     get:
       consumes:
       - application/json
@@ -2426,7 +2884,7 @@ paths:
       summary: Get a transaction by ID
       tags:
       - transactions
-  /api/transactions/branch/{branch_id}:
+  /api/v1/admin/transactions/branch/{branch_id}:
     get:
       consumes:
       - application/json
@@ -2497,7 +2955,7 @@ paths:
       summary: Get transactions by query parameters
       tags:
       - transactions
-  /api/transactions/docs/initiator_type:
+  /api/v1/admin/transactions/docs/initiator_type:
     get:
       consumes:
       - application/json
@@ -2516,7 +2974,7 @@ paths:
       summary: Get all initiator types
       tags:
       - transactions
-  /api/transactions/docs/payment_method:
+  /api/v1/admin/transactions/docs/payment_method:
     get:
       consumes:
       - application/json
@@ -2535,7 +2993,7 @@ paths:
       summary: Get all payment methods
       tags:
       - transactions
-  /api/transactions/docs/type:
+  /api/v1/admin/transactions/docs/type:
     get:
       consumes:
       - application/json
@@ -2554,64 +3012,825 @@ paths:
       summary: Get all transaction types
       tags:
       - transactions
-  /auth/login:
-    post:
-      consumes:
-      - application/json
-      description: Authenticate user and return a token
-      parameters:
-      - description: User credentials
-        in: body
-        name: user
-        required: true
-        schema:
-          $ref: '#/definitions/auth.LoginInput'
+  /api/v1/store/account/addresses:
+    get:
       produces:
       - application/json
       responses:
-        "200":
-          description: token
+        "501":
+          description: Not Implemented
           schema:
-            additionalProperties:
-              type: string
-            type: object
-        "401":
-          description: Unauthorized
-          schema:
-            type: string
-        "500":
-          description: Internal Server Error
-          schema:
-            type: string
-      summary: Login a user
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: List the customer's saved addresses
       tags:
-      - auth
-  /auth/register:
+      - store-account
     post:
-      consumes:
-      - application/json
-      description: Create a new user account
-      parameters:
-      - description: User credentials
-        in: body
-        name: user
-        required: true
-        schema:
-          $ref: '#/definitions/models.User'
       produces:
       - application/json
       responses:
-        "201":
-          description: Created
+        "501":
+          description: Not Implemented
           schema:
-            type: string
-        "500":
-          description: Internal Server Error
-          schema:
-            type: string
-      summary: Register a new user
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Add a new address to the customer's address book
       tags:
-      - auth
+      - store-account
+  /api/v1/store/account/addresses/{address_id}:
+    delete:
+      parameters:
+      - description: Address ID
+        in: path
+        name: address_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Delete an address
+      tags:
+      - store-account
+    put:
+      parameters:
+      - description: Address ID
+        in: path
+        name: address_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Update an address
+      tags:
+      - store-account
+  /api/v1/store/account/addresses/{address_id}/default:
+    put:
+      parameters:
+      - description: Address ID
+        in: path
+        name: address_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Mark an address as the default
+      tags:
+      - store-account
+  /api/v1/store/auth/login:
+    post:
+      consumes:
+      - application/json
+      description: Authenticate a storefront customer and return a token
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Login a storefront customer
+      tags:
+      - store-auth
+  /api/v1/store/auth/logout:
+    post:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Logout the current storefront customer
+      tags:
+      - store-auth
+  /api/v1/store/auth/me:
+    get:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Get current storefront customer profile
+      tags:
+      - store-auth
+    put:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Update current storefront customer profile
+      tags:
+      - store-auth
+  /api/v1/store/auth/password/forgot:
+    post:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Request a password reset
+      tags:
+      - store-auth
+  /api/v1/store/auth/password/reset:
+    post:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Reset a password with a reset token
+      tags:
+      - store-auth
+  /api/v1/store/auth/refresh:
+    post:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Refresh a storefront access token
+      tags:
+      - store-auth
+  /api/v1/store/auth/register:
+    post:
+      consumes:
+      - application/json
+      description: Create a new storefront customer account
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Register a storefront customer
+      tags:
+      - store-auth
+  /api/v1/store/cart:
+    delete:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Empty the cart
+      tags:
+      - store-cart
+    get:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Get the current customer's cart
+      tags:
+      - store-cart
+  /api/v1/store/cart/items:
+    post:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Add an item to the cart
+      tags:
+      - store-cart
+  /api/v1/store/cart/items/{item_id}:
+    delete:
+      parameters:
+      - description: Cart item ID
+        in: path
+        name: item_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Remove an item from the cart
+      tags:
+      - store-cart
+    put:
+      parameters:
+      - description: Cart item ID
+        in: path
+        name: item_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Update a cart item's quantity
+      tags:
+      - store-cart
+  /api/v1/store/cart/promo:
+    delete:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Remove the applied coupon from the cart
+      tags:
+      - store-cart
+    post:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Apply a coupon code to the cart
+      tags:
+      - store-cart
+  /api/v1/store/catalog/brands:
+    get:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: List brands / manufacturers
+      tags:
+      - store-catalog
+  /api/v1/store/catalog/categories:
+    get:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: List catalog categories
+      tags:
+      - store-catalog
+  /api/v1/store/catalog/categories/{id}:
+    get:
+      parameters:
+      - description: Category ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Get a category by id
+      tags:
+      - store-catalog
+  /api/v1/store/catalog/categories/{id}/products:
+    get:
+      parameters:
+      - description: Category ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: List products in a category
+      tags:
+      - store-catalog
+  /api/v1/store/catalog/search:
+    get:
+      description: Full-text search with filters, facets, sort and pagination
+      parameters:
+      - description: Search query
+        in: query
+        name: q
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Search the catalog
+      tags:
+      - store-catalog
+  /api/v1/store/checkout/preview:
+    post:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Preview checkout totals (items, shipping, tax) before placing an order
+      tags:
+      - store-orders
+  /api/v1/store/orders:
+    get:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: List the customer's orders
+      tags:
+      - store-orders
+    post:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Place an order from the current cart
+      tags:
+      - store-orders
+  /api/v1/store/orders/{id}:
+    get:
+      parameters:
+      - description: Order ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Get an order by id
+      tags:
+      - store-orders
+  /api/v1/store/orders/{id}/cancel:
+    post:
+      parameters:
+      - description: Order ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Cancel an order
+      tags:
+      - store-orders
+  /api/v1/store/orders/{id}/reorder:
+    post:
+      parameters:
+      - description: Order ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Re-add the items of a past order to the cart
+      tags:
+      - store-orders
+  /api/v1/store/orders/{id}/status:
+    get:
+      parameters:
+      - description: Order ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Get an order's status / tracking
+      tags:
+      - store-orders
+  /api/v1/store/products:
+    get:
+      description: List products with filter/sort/pagination
+      parameters:
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Items per page
+        in: query
+        name: count
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: List storefront products
+      tags:
+      - store-products
+  /api/v1/store/products/{id}:
+    get:
+      parameters:
+      - description: Product ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Get a storefront product by id
+      tags:
+      - store-products
+  /api/v1/store/products/{id}/availability:
+    get:
+      parameters:
+      - description: Product ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Get a product's stock availability per branch
+      tags:
+      - store-products
+  /api/v1/store/products/{id}/images:
+    get:
+      parameters:
+      - description: Product ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Get a product's images
+      tags:
+      - store-products
+  /api/v1/store/products/{id}/related:
+    get:
+      parameters:
+      - description: Product ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Get related / recommended products
+      tags:
+      - store-products
+  /api/v1/store/products/{id}/reviews:
+    get:
+      parameters:
+      - description: Product ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: List reviews for a product (public)
+      tags:
+      - store-products
+    post:
+      parameters:
+      - description: Product ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Create a review for a product
+      tags:
+      - store-reviews
+  /api/v1/store/promotions:
+    get:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: List active promotions / banners
+      tags:
+      - store-promotions
+  /api/v1/store/promotions/{id}:
+    get:
+      parameters:
+      - description: Promotion ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Get a promotion by id
+      tags:
+      - store-promotions
+  /api/v1/store/promotions/coupons/{code}:
+    get:
+      parameters:
+      - description: Coupon code
+        in: path
+        name: code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      summary: Look up a coupon's terms by code
+      tags:
+      - store-promotions
+  /api/v1/store/promotions/validate:
+    post:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Validate a coupon against the current cart / customer
+      tags:
+      - store-promotions
+  /api/v1/store/reviews/{id}:
+    delete:
+      parameters:
+      - description: Review ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Delete the caller's own review
+      tags:
+      - store-reviews
+    put:
+      parameters:
+      - description: Review ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Update the caller's own review
+      tags:
+      - store-reviews
+  /api/v1/store/reviews/{id}/vote:
+    post:
+      parameters:
+      - description: Review ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Vote a review helpful / unhelpful
+      tags:
+      - store-reviews
+  /api/v1/store/wishlist:
+    get:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Get the current customer's wishlist
+      tags:
+      - store-wishlist
+  /api/v1/store/wishlist/items:
+    post:
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Add a product to the wishlist
+      tags:
+      - store-wishlist
+  /api/v1/store/wishlist/items/{product_id}:
+    delete:
+      parameters:
+      - description: Product ID
+        in: path
+        name: product_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Remove a product from the wishlist
+      tags:
+      - store-wishlist
+  /api/v1/store/wishlist/items/{product_id}/move-to-cart:
+    post:
+      parameters:
+      - description: Product ID
+        in: path
+        name: product_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorOutput'
+      security:
+      - BearerAuth: []
+      summary: Move a wishlist product into the cart
+      tags:
+      - store-wishlist
   /proposals:
     delete:
       description: Configures proxy routes based on server configuration to forward

--- a/pkg/app/controllers.go
+++ b/pkg/app/controllers.go
@@ -13,6 +13,7 @@ import (
 	journal_handlers "github.com/aslon1213/g4h_pos_erp/pkg/controllers/journals"
 	"github.com/aslon1213/g4h_pos_erp/pkg/controllers/products"
 	"github.com/aslon1213/g4h_pos_erp/pkg/controllers/sales"
+	"github.com/aslon1213/g4h_pos_erp/pkg/controllers/store"
 	"github.com/aslon1213/g4h_pos_erp/pkg/controllers/suppliers"
 	"github.com/aslon1213/g4h_pos_erp/pkg/controllers/transactions"
 	"github.com/aslon1213/g4h_pos_erp/pkg/middleware"
@@ -37,6 +38,7 @@ type Controllers struct {
 	Middlewares  *middleware.Middlewares
 	Dashboard    *analytics.DashboardHandler
 	Proposals    *arrivals.ProposalsHandlers
+	Store        *store.Controllers
 }
 
 func NewControllers(db *mongo.Database) *Controllers {
@@ -56,6 +58,7 @@ func NewControllers(db *mongo.Database) *Controllers {
 		Middlewares:  middleware,
 		Dashboard:    analytics.New(db),
 		Proposals:    arrivals.New(db),
+		Store:        store.New(db),
 	}
 	log.Debug().Msg("Controllers initialized successfully")
 	return controllers
@@ -71,6 +74,27 @@ func SetupRoutes(app *fiber.App, controllers *Controllers) {
 	if err != nil {
 		log.Fatal().Err(err).Msg("invalid symmetric key")
 	}
+
+	// Public routes must be registered BEFORE the /api token guard below, so the
+	// PASETO middleware does not apply to them (e.g. login can't require a token).
+	routes.PublicAuthRoutes(app, controllers.Auth, controllers.Middlewares)
+	log.Debug().Msg("Public auth routes set up successfully")
+
+	// Storefront API (/api/v1/store). These are registered before the staff /api
+	// guard so they do NOT inherit the staff (users-collection) auth. Public store
+	// routes get no guard; protected ones get their own customer-token guard below.
+	routes.StorePublicRoutes(app, controllers.Store, controllers.Middlewares)
+	log.Debug().Msg("Store public routes set up successfully")
+
+	app.Group("/api/v1/store", pasetoware.New(
+		pasetoware.Config{
+			SymmetricKey:   keyBytes,
+			SuccessHandler: controllers.Middlewares.CustomerAuthMiddleware,
+		},
+	))
+	routes.StoreProtectedRoutes(app, controllers.Store, controllers.Middlewares)
+	log.Debug().Msg("Store protected routes set up successfully")
+
 	app.Group("/api", pasetoware.New(
 		pasetoware.Config{
 			SymmetricKey: keyBytes,

--- a/pkg/controllers/arrivals/proposals.go
+++ b/pkg/controllers/arrivals/proposals.go
@@ -33,17 +33,16 @@ func New(db *mongo.Database) *ProposalsHandlers {
 	}
 }
 
-// GetImage handles GET /api/proposals/images
+// GetImage godoc
 // @Summary Get image by name
 // @Description Retrieves an image file by its name
-// @Tags proposals
 // @Security BearerAuth
-// @Accept json
+// @Tags proposals
 // @Produce octet-stream
 // @Param image_name query string true "Image name"
-// @Success 200 {file} file "Image file"
-// @Failure 404 {object} map[string]string "Image not found"
-// @Router /api/proposals/images [get]
+// @Success 200 {file} binary "Image file"
+// @Failure 404 {object} models.ErrorOutput "Image not found"
+// @Router /api/v1/admin/proposals/images [get]
 func (h *ProposalsHandlers) GetImage(c *fiber.Ctx) error {
 	tracer := otel.Tracer("proposals-handlers")
 	_, span := tracer.Start(h.ctx, "GetImage")
@@ -62,18 +61,17 @@ func (h *ProposalsHandlers) GetImage(c *fiber.Ctx) error {
 	return c.SendFile(imagePath)
 }
 
-// GetImageByProposalID handles GET /api/proposals/image
+// GetImageByProposalID godoc
 // @Summary Get image upload page by proposal ID
 // @Description Retrieves the image upload page for a specific proposal record
-// @Tags proposals
 // @Security BearerAuth
-// @Accept json
+// @Tags proposals
 // @Produce html
 // @Param proposal_id query string true "Proposal ID"
 // @Success 200 {string} string "HTML page"
-// @Failure 400 {object} map[string]string "Invalid proposal ID"
-// @Failure 404 {object} map[string]string "Proposal not found"
-// @Router /api/proposals/image [get]
+// @Failure 400 {object} models.ErrorOutput "Invalid proposal ID"
+// @Failure 404 {object} models.ErrorOutput "Proposal not found"
+// @Router /api/v1/admin/proposals/image [get]
 func (h *ProposalsHandlers) GetImageByProposalID(c *fiber.Ctx) error {
 	tracer := otel.Tracer("proposals-handlers")
 	ctx, span := tracer.Start(h.ctx, "GetImageByProposalID")
@@ -104,20 +102,20 @@ func (h *ProposalsHandlers) GetImageByProposalID(c *fiber.Ctx) error {
 	})
 }
 
-// UploadImage handles POST /api/proposals/image
+// UploadImage godoc
 // @Summary Upload image for proposal
 // @Description Uploads an image file for a specific proposal record
-// @Tags proposals
 // @Security BearerAuth
+// @Tags proposals
 // @Accept multipart/form-data
 // @Produce json
 // @Param proposal_id query string true "Proposal ID"
 // @Param file formData file true "Image file to upload"
 // @Success 303 {string} string "Redirect to proposals list"
-// @Failure 400 {object} map[string]string "Invalid proposal ID or no file uploaded"
-// @Failure 404 {object} map[string]string "Proposal not found"
-// @Failure 500 {object} map[string]string "Failed to save file or update proposal"
-// @Router /api/proposals/image [post]
+// @Failure 400 {object} models.ErrorOutput "Invalid proposal ID or no file uploaded"
+// @Failure 404 {object} models.ErrorOutput "Proposal not found"
+// @Failure 500 {object} models.ErrorOutput "Failed to save file or update proposal"
+// @Router /api/v1/admin/proposals/image [post]
 func (h *ProposalsHandlers) UploadImage(c *fiber.Ctx) error {
 	tracer := otel.Tracer("proposals-handlers")
 	ctx, span := tracer.Start(h.ctx, "UploadImage")
@@ -189,19 +187,19 @@ func (h *ProposalsHandlers) UploadImage(c *fiber.Ctx) error {
 	return c.Redirect("/proposals/", http.StatusSeeOther)
 }
 
-// NewProposals handles POST /api/proposals/new
+// NewProposals godoc
 // @Summary Create new proposals
 // @Description Creates new proposal records for a specific branch
-// @Tags proposals
 // @Security BearerAuth
+// @Tags proposals
 // @Accept json
 // @Produce json
 // @Param branch query string true "Branch name"
 // @Param body body []string true "List of proposal names"
-// @Success 200 {object} map[string]interface{} "Proposals created successfully"
-// @Failure 400 {object} map[string]string "Invalid branch or request body"
-// @Failure 500 {object} map[string]string "Failed to create proposals"
-// @Router /api/proposals/new [post]
+// @Success 200 {object} models.MessageResponse "Proposals created successfully"
+// @Failure 400 {object} models.ErrorOutput "Invalid branch or request body"
+// @Failure 500 {object} models.ErrorOutput "Failed to create proposals"
+// @Router /api/v1/admin/proposals/new [post]
 func (h *ProposalsHandlers) NewProposals(c *fiber.Ctx) error {
 	tracer := otel.Tracer("proposals-handlers")
 	ctx, span := tracer.Start(h.ctx, "NewProposals")
@@ -257,22 +255,21 @@ func (h *ProposalsHandlers) NewProposals(c *fiber.Ctx) error {
 	})
 }
 
-// GetProposals handles GET /api/proposals
+// GetProposals godoc
 // @Summary Get all proposals
 // @Description Retrieves all proposals with optional filters
-// @Tags proposals
 // @Security BearerAuth
-// @Accept json
+// @Tags proposals
 // @Produce json
 // @Param name query string false "Filter by name (case-insensitive)"
 // @Param branch query string false "Filter by branch (case-insensitive)"
 // @Param fulfilled query string false "Filter by fulfilled status (true/false)" default(false)
 // @Param date_from query string false "Filter by start date (YYYY-MM-DD)"
 // @Param date_to query string false "Filter by end date (YYYY-MM-DD)"
-// @Success 200 {array} map[string]interface{} "List of proposals"
-// @Failure 400 {object} map[string]string "Invalid date format"
-// @Failure 500 {object} map[string]string "Failed to fetch or decode proposals"
-// @Router /api/proposals [get]
+// @Success 200 {array} models.ProductProposal "List of proposals"
+// @Failure 400 {object} models.ErrorOutput "Invalid date format"
+// @Failure 500 {object} models.ErrorOutput "Failed to fetch or decode proposals"
+// @Router /api/v1/admin/proposals [get]
 func (h *ProposalsHandlers) GetProposals(c *fiber.Ctx) error {
 	tracer := otel.Tracer("proposals-handlers")
 	ctx, span := tracer.Start(h.ctx, "GetProposals")
@@ -370,18 +367,17 @@ func (h *ProposalsHandlers) GetProposals(c *fiber.Ctx) error {
 	return c.JSON(response)
 }
 
-// GetProposalDetail handles GET /api/proposals/detail
+// GetProposalDetail godoc
 // @Summary Get proposal detail
 // @Description Retrieves detailed information for a specific proposal record
-// @Tags proposals
 // @Security BearerAuth
-// @Accept json
+// @Tags proposals
 // @Produce html
 // @Param proposal_id query string true "Proposal ID"
 // @Success 200 {string} string "HTML page with proposal details"
-// @Failure 400 {object} map[string]string "Invalid proposal ID"
-// @Failure 404 {object} map[string]string "Proposal not found"
-// @Router /api/proposals/detail [get]
+// @Failure 400 {object} models.ErrorOutput "Invalid proposal ID"
+// @Failure 404 {object} models.ErrorOutput "Proposal not found"
+// @Router /api/v1/admin/proposals/detail [get]
 func (h *ProposalsHandlers) GetProposalDetail(c *fiber.Ctx) error {
 	tracer := otel.Tracer("proposals-handlers")
 	ctx, span := tracer.Start(h.ctx, "GetProposalDetail")
@@ -425,19 +421,19 @@ type EditProposalRequest struct {
 	Fulfilled *bool  `json:"fulfilled" form:"fulfilled"`
 }
 
-// EditProposal handles put /api/proposals/edit
+// EditProposal godoc
 // @Summary Edit proposal
 // @Description Updates an existing proposal record
-// @Tags proposals
 // @Security BearerAuth
-// @Accept json,application/x-www-form-urlencoded
+// @Tags proposals
+// @Accept json
 // @Produce json
 // @Param proposal_id query string true "Proposal ID"
 // @Param body body EditProposalRequest false "Proposal update data"
 // @Success 302 {string} string "Redirect to proposals list"
-// @Failure 400 {object} map[string]string "Invalid proposal ID or request data"
-// @Failure 500 {object} map[string]string "Failed to update proposal"
-// @Router /api/proposals/edit [put]
+// @Failure 400 {object} models.ErrorOutput "Invalid proposal ID or request data"
+// @Failure 500 {object} models.ErrorOutput "Failed to update proposal"
+// @Router /api/v1/admin/proposals/edit [put]
 func (h *ProposalsHandlers) EditProposal(c *fiber.Ctx) error {
 	tracer := otel.Tracer("proposals-handlers")
 	ctx, span := tracer.Start(h.ctx, "EditProposal")
@@ -484,19 +480,18 @@ func (h *ProposalsHandlers) EditProposal(c *fiber.Ctx) error {
 	return c.Redirect("/proposals", http.StatusFound)
 }
 
-// DeleteProposal handles DELETE /api/proposals/delete
+// DeleteProposal godoc
 // @Summary Delete proposal
 // @Description Deletes a proposal record and its associated image file
-// @Tags proposals
 // @Security BearerAuth
-// @Accept json
+// @Tags proposals
 // @Produce json
 // @Param proposal_id query string true "Proposal ID"
 // @Success 302 {string} string "Redirect to proposals list"
-// @Failure 400 {object} map[string]string "Invalid proposal ID"
-// @Failure 404 {object} map[string]string "Proposal not found"
-// @Failure 500 {object} map[string]string "Failed to delete proposal"
-// @Router /api/proposals/delete [delete]
+// @Failure 400 {object} models.ErrorOutput "Invalid proposal ID"
+// @Failure 404 {object} models.ErrorOutput "Proposal not found"
+// @Failure 500 {object} models.ErrorOutput "Failed to delete proposal"
+// @Router /api/v1/admin/proposals/delete [delete]
 func (h *ProposalsHandlers) DeleteProposal(c *fiber.Ctx) error {
 	tracer := otel.Tracer("proposals-handlers")
 	ctx, span := tracer.Start(h.ctx, "DeleteProposal")
@@ -544,19 +539,18 @@ func (h *ProposalsHandlers) DeleteProposal(c *fiber.Ctx) error {
 	return c.Redirect("/proposals", http.StatusFound)
 }
 
-// FulfillProposals handles GET /api/proposals/fulfill
+// FulfillProposals godoc
 // @Summary Fulfill proposals
 // @Description Marks multiple proposals as fulfilled for a specific branch
-// @Tags proposals
 // @Security BearerAuth
-// @Accept json
+// @Tags proposals
 // @Produce json
 // @Param branch query string true "Branch name"
 // @Param ids query string true "Comma-separated list of proposal IDs"
-// @Success 200 {object} map[string]interface{} "Fulfillment result"
-// @Failure 400 {object} map[string]string "Invalid branch or no valid IDs provided"
-// @Failure 500 {object} map[string]string "Failed to fulfill proposals"
-// @Router /api/proposals/fulfill [get]
+// @Success 200 {object} models.MessageResponse "Fulfillment result"
+// @Failure 400 {object} models.ErrorOutput "Invalid branch or no valid IDs provided"
+// @Failure 500 {object} models.ErrorOutput "Failed to fulfill proposals"
+// @Router /api/v1/admin/proposals/fulfill [get]
 func (h *ProposalsHandlers) FulfillProposals(c *fiber.Ctx) error {
 	tracer := otel.Tracer("proposals-handlers")
 	ctx, span := tracer.Start(h.ctx, "FulfillProposals")
@@ -628,16 +622,15 @@ func (h *ProposalsHandlers) FulfillProposals(c *fiber.Ctx) error {
 	})
 }
 
-// GeneratePDF handles GET /api/proposals/pdf/pdf
+// GeneratePDF godoc
 // @Summary Generate PDF
 // @Description Generates a PDF document with unfulfilled proposals
-// @Tags proposals
 // @Security BearerAuth
-// @Accept json
+// @Tags proposals
 // @Produce json
-// @Success 200 {object} map[string]interface{} "PDF generation result with proposals data"
-// @Failure 500 {object} map[string]string "Failed to fetch or decode proposals"
-// @Router /api/proposals/pdf/pdf [get]
+// @Success 200 {object} models.MessageResponse "PDF generation result with proposals data"
+// @Failure 500 {object} models.ErrorOutput "Failed to fetch or decode proposals"
+// @Router /api/v1/admin/proposals/pdf/pdf [get]
 func (h *ProposalsHandlers) GeneratePDF(c *fiber.Ctx) error {
 	tracer := otel.Tracer("proposals-handlers")
 	ctx, span := tracer.Start(h.ctx, "GeneratePDF")

--- a/pkg/controllers/auth/auth.go
+++ b/pkg/controllers/auth/auth.go
@@ -58,33 +58,32 @@ type LoginInput struct {
 	Password string `json:"password" validate:"required"`
 }
 
-// Info handles user info
+// InfoMe godoc
 // @Summary Get user info
-// @Security BearerAuth
 // @Description Get user info
+// @Security BearerAuth
 // @Tags auth
-// @Accept json
 // @Produce json
-// @Success 200 {object} map[string]string "message"
-// @Failure 500 {string} string "Internal Server Error"
-// @Router /api/auth/me [get]
+// @Success 200 {object} models.MessageResponse "message"
+// @Failure 500 {object} models.ErrorOutput "Internal Server Error"
+// @Router /api/v1/admin/auth/me [get]
 func (a *AuthControllers) InfoMe(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{
 		"message": "Hello, World!",
 	})
 }
 
-// Login handles user login
+// Login godoc
 // @Summary Login a user
 // @Description Authenticate user and return a token
 // @Tags auth
 // @Accept json
 // @Produce json
 // @Param user body LoginInput true "User credentials"
-// @Success 200 {object} map[string]string "token"
-// @Failure 500 {string} string "Internal Server Error"
-// @Failure 401 {string} string "Unauthorized"
-// @Router /auth/login [post]
+// @Success 200 {object} models.TokenResponse "token"
+// @Failure 401 {object} models.ErrorOutput "Unauthorized"
+// @Failure 500 {object} models.ErrorOutput "Internal Server Error"
+// @Router /api/v1/admin/auth/login [post]
 func (a *AuthControllers) Login(c *fiber.Ctx) error {
 	var user_to_check LoginInput
 
@@ -156,16 +155,17 @@ func (a *AuthControllers) Login(c *fiber.Ctx) error {
 	return c.JSON(payload)
 }
 
-// Register handles user registration
+// Register godoc
 // @Summary Register a new user
 // @Description Create a new user account
 // @Tags auth
 // @Accept json
 // @Produce json
-// @Param user body models.User true "User credentials"
+// @Param user body models.UserRegisterInput true "User credentials"
 // @Success 201 {string} string "Created"
-// @Failure 500 {string} string "Internal Server Error"
-// @Router /auth/register [post]
+// @Failure 500 {object} models.ErrorOutput "Internal Server Error"
+// register endpoint disabled -- route commented out in routes.PublicAuthRoutes
+// // @Router /api/v1/admin/auth/register [post]
 func (a *AuthControllers) Register(c *fiber.Ctx) error {
 	// Parse user input
 	var user models.UserRegisterInput
@@ -215,11 +215,10 @@ func (a *AuthControllers) Register(c *fiber.Ctx) error {
 // @Security BearerAuth
 // @Description Get the 25 most recent activities across all users
 // @Tags auth
-// @Accept json
 // @Produce json
-// @Success 200 {object} models.Output
-// @Failure 500 {object} models.Output "Internal Server Error"
-// @Router /api/activities/recent [get]
+// @Success 200 {object} models.Output[[]middleware.Activity]
+// @Failure 500 {object} models.ErrorOutput "Internal Server Error"
+// @Router /api/v1/admin/activities/recent [get]
 func (a *AuthControllers) GetRecentActivities(c *fiber.Ctx) error {
 	log.Info().Msg("Getting recent activities")
 	activities, err := a.ActivitiesCollection.Find(c.Context(), bson.M{}, options.Find().SetSort(bson.M{"date": -1}).SetLimit(25))
@@ -243,11 +242,10 @@ func (a *AuthControllers) GetRecentActivities(c *fiber.Ctx) error {
 // @Security BearerAuth
 // @Description Get the 25 most recent activities for the authenticated user
 // @Tags auth
-// @Accept json
 // @Produce json
-// @Success 200 {object} models.Output
-// @Failure 500 {object} models.Output "Internal Server Error"
-// @Router /api/activities/me [get]
+// @Success 200 {object} models.Output[[]middleware.Activity]
+// @Failure 500 {object} models.ErrorOutput "Internal Server Error"
+// @Router /api/v1/admin/activities/me [get]
 func (a *AuthControllers) GetActivitesOfUser(c *fiber.Ctx) error {
 	log.Info().Str("user", c.Locals("user").(string)).Msg("Getting activities of user")
 	activities, err := a.ActivitiesCollection.Find(c.Context(), bson.M{"user_id": c.Locals("user").(string)}, options.Find().SetSort(bson.M{"date": -1}).SetLimit(25))

--- a/pkg/controllers/customers/bnpl/bnpl.go
+++ b/pkg/controllers/customers/bnpl/bnpl.go
@@ -38,10 +38,10 @@ func New(db *mongo.Database) *BNPLController {
 // @Accept json
 // @Produce json
 // @Param input body models.NewBNPLInput true "BNPL input"
-// @Success 200 {object} models.Output
-// @Failure 400 {object} models.Error
-// @Failure 500 {object} models.Error
-// @Router /api/bnpl [post]
+// @Success 200 {object} models.Output[[]models.BNPL]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/bnpl [post]
 func (ctrl *BNPLController) NewBNPL(c *fiber.Ctx) error {
 	log.Info().Msg("Creating new BNPL")
 
@@ -119,9 +119,9 @@ func (ctrl *BNPLController) NewBNPL(c *fiber.Ctx) error {
 // @Param id path string true "BNPL ID"
 // @Param amount query int true "Payment amount"
 // @Param payment_method query string false "Payment method" default(cash)
-// @Success 200 {object} models.BNPL
-// @Failure 500 {object} models.Error
-// @Router /api/bnpl/{id}/credit [post]
+// @Success 200 {object} models.Output[[]models.BNPL]
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/bnpl/{id}/credit [post]
 func (ctrl *BNPLController) CreditBNPL(c *fiber.Ctx) error {
 	log.Info().Msg("Processing BNPL credit payment")
 
@@ -259,12 +259,11 @@ func (ctrl *BNPLController) CreditBNPL(c *fiber.Ctx) error {
 // @Security BearerAuth
 // @Description Delete an existing BNPL transaction
 // @Tags BNPL
-// @Accept json
 // @Produce json
 // @Param id path string true "BNPL ID"
-// @Success 200 {object} map[string]string
-// @Failure 500 {object} models.Error
-// @Router /api/bnpl/{id} [delete]
+// @Success 200 {object} models.MessageResponse
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/bnpl/{id} [delete]
 func (ctrl *BNPLController) DeleteBNPL(c *fiber.Ctx) error {
 	log.Info().Msg("Deleting BNPL")
 
@@ -300,12 +299,11 @@ func (ctrl *BNPLController) DeleteBNPL(c *fiber.Ctx) error {
 // @Security BearerAuth
 // @Description Get details of a specific BNPL transaction
 // @Tags BNPL
-// @Accept json
 // @Produce json
 // @Param id path string true "BNPL ID"
-// @Success 200 {object} models.Output
-// @Failure 500 {object} models.Error
-// @Router /api/bnpl/{id} [get]
+// @Success 200 {object} models.Output[models.BNPL]
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/bnpl/{id} [get]
 func (ctrl *BNPLController) GetBNPLByID(c *fiber.Ctx) error {
 	log.Info().Msg("Getting BNPL details")
 
@@ -375,13 +373,12 @@ func GetBNPLByIDFromDB(ctx context.Context, bnpl_id string, customersCollection 
 // @Security BearerAuth
 // @Description Get all BNPL transactions for a specific customer
 // @Tags BNPL
-// @Accept json
 // @Produce json
 // @Param customer_id path string true "Customer ID"
 // @Param branch_id query string false "Branch ID"
-// @Success 200 {object} models.Output
-// @Failure 500 {object} models.Error
-// @Router /api/customers/{customer_id}/bnpls [get]
+// @Success 200 {object} models.Output[[]models.BNPL]
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/customers/{customer_id}/bnpls [get]
 func (ctrl *BNPLController) GetBNPLSofCustomer(c *fiber.Ctx) error {
 	log.Info().Msg("Getting customer BNPLs")
 	branch_id := c.Query("branch_id")
@@ -405,20 +402,19 @@ func (ctrl *BNPLController) GetBNPLSofCustomer(c *fiber.Ctx) error {
 	return c.JSON(models.NewOutput(customer.BNPLs))
 }
 
-// Get BNPLs of branch
+// GetBNPLsOfBranch godoc
 // @Summary Get BNPLs of branch
 // @Security BearerAuth
 // @Description Get all BNPL transactions for a specific branch
 // @Tags BNPL
-// @Accept json
 // @Produce json
 // @Param branch_id path string true "Branch ID"
 // @Param customer_name query string false "Customer name"
 // @Param customer_phone query string false "Customer phone"
 // @Param customer_address query string false "Customer address"
-// @Success 200 {object} models.Output
-// @Failure 500 {object} models.Error
-// @Router /api/branches/{branch_id}/bnpls [get]
+// @Success 200 {object} models.Output[[]models.Customer]
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/branches/{branch_id}/bnpls [get]
 func (ctrl *BNPLController) GetBNPLsOfBranch(c *fiber.Ctx) error {
 	log.Info().Msg("Getting BNPLs of branch")
 

--- a/pkg/controllers/customers/customer.go
+++ b/pkg/controllers/customers/customer.go
@@ -72,9 +72,10 @@ func (query *CustomerQuery) SetDefaults() {
 // @Param page query int false "Page number"
 // @Param count query int false "Number of customers per page"
 // @Param sort_by_bnpl_total query string false "Sort by BNPL total (max, min, none)"
-// @Success 200 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/customers [get]
+// @Success 200 {object} models.CustomerQueryOutput
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/customers [get]
 func (ctrl *CustomersController) GetCustomers(c *fiber.Ctx) error {
 	var query CustomerQuery
 	if err := c.QueryParser(&query); err != nil {
@@ -184,13 +185,12 @@ func (ctrl *CustomersController) GetCustomers(c *fiber.Ctx) error {
 // @Summary Get a customer by ID
 // @Description Get a customer by its ID
 // @Tags customers
-// @Accept json
 // @Produce json
 // @Param id path string true "Customer ID"
-// @Success 200 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/customers/{id} [get]
+// @Success 200 {object} models.Output[[]models.Customer]
+// @Failure 404 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/customers/{id} [get]
 func (ctrl *CustomersController) GetCustomerByID(c *fiber.Ctx) error {
 	id := c.Params("id")
 	log.Debug().Str("id", id).Msg("Getting customer by ID")
@@ -224,10 +224,11 @@ func (ctrl *CustomersController) GetCustomerByID(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Param customer body models.CustomerBase true "Customer data"
-// @Success 201 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/customers [post]
+// @Success 201 {object} models.Output[[]models.Customer]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 409 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/customers [post]
 func (ctrl *CustomersController) CreateCustomer(c *fiber.Ctx) error {
 	log.Debug().Msg("Creating new customer")
 
@@ -296,11 +297,12 @@ func (ctrl *CustomersController) CreateCustomer(c *fiber.Ctx) error {
 // @Produce json
 // @Param id path string true "Customer ID"
 // @Param customer body models.CustomerBase true "Customer data"
-// @Success 200 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/customers/{id} [put]
+// @Success 200 {object} models.Output[[]models.Customer]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 404 {object} models.ErrorOutput
+// @Failure 409 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/customers/{id} [put]
 func (ctrl *CustomersController) UpdateCustomer(c *fiber.Ctx) error {
 	id := c.Params("id")
 	log.Debug().Str("id", id).Msg("Updating customer")
@@ -399,13 +401,13 @@ func (ctrl *CustomersController) UpdateCustomer(c *fiber.Ctx) error {
 // @Summary Delete a customer
 // @Description Delete a customer from the database
 // @Tags customers
-// @Accept json
 // @Produce json
 // @Param id path string true "Customer ID"
-// @Success 200 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/customers/{id} [delete]
+// @Success 200 {object} models.MessageResponse
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 404 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/customers/{id} [delete]
 func (ctrl *CustomersController) DeleteCustomer(c *fiber.Ctx) error {
 	id := c.Params("id")
 	log.Debug().Str("id", id).Msg("Deleting customer")

--- a/pkg/controllers/finance/finance.go
+++ b/pkg/controllers/finance/finance.go
@@ -46,9 +46,9 @@ func New(db *mongo.Database) *FinanceController {
 // @Description Retrieve all branches from the finance collection
 // @Tags finance
 // @Produce json
-// @Success 200 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/finance/branches [get]
+// @Success 200 {object} models.Output[[]models.BranchFinance]
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/finance/branches [get]
 func (f *FinanceController) GetBranches(c *fiber.Ctx) error {
 	log.Debug().Msg("Fetching all branches")
 	cursor, err := f.FinanceCollection.Find(context.Background(), bson.M{})
@@ -83,9 +83,9 @@ func (f *FinanceController) GetBranches(c *fiber.Ctx) error {
 // @Tags finance
 // @Param id path string true "Branch ID"
 // @Produce json
-// @Success 200 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Router /api/finance/branch/id/{id} [get]
+// @Success 200 {object} models.Output[models.BranchFinance]
+// @Failure 404 {object} models.ErrorOutput
+// @Router /api/v1/admin/finance/branch/id/{id} [get]
 func (f *FinanceController) GetFinanceBranchByBranchID(c *fiber.Ctx) error {
 	branchID := c.Params("id")
 	log.Debug().Str("branch_id", branchID).Msg("Fetching branch by ID")
@@ -109,9 +109,9 @@ func (f *FinanceController) GetFinanceBranchByBranchID(c *fiber.Ctx) error {
 // @Tags finance
 // @Param branch_name path string true "Branch Name"
 // @Produce json
-// @Success 200 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Router /api/finance/branch/name/{branch_name} [get]
+// @Success 200 {object} models.Output[models.BranchFinance]
+// @Failure 404 {object} models.ErrorOutput
+// @Router /api/v1/admin/finance/branch/name/{branch_name} [get]
 func (f *FinanceController) GetFinanceByBranchName(c *fiber.Ctx) error {
 	branchName := c.Params("branch_name")
 	log.Debug().Str("branch_name", branchName).Msg("Fetching finance by branch name")
@@ -140,10 +140,10 @@ func (f *FinanceController) GetFinanceByBranchName(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Param branch body models.NewBranchFinanceInput true "Branch finance input"
-// @Success 201 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/finance [post]
+// @Success 201 {object} models.Output[models.BranchFinance]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/finance [post]
 func (f *FinanceController) NewFinanceOfBranch(c *fiber.Ctx) error {
 	log.Debug().Msg("Creating new finance for branch")
 	var Input models.NewBranchFinanceInput
@@ -190,9 +190,10 @@ func (f *FinanceController) NewFinanceOfBranch(c *fiber.Ctx) error {
 // @Tags finance
 // @Param id path string true "Finance ID"
 // @Produce json
-// @Success 200 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Router /api/finance/id/{id} [get]
+// @Success 200 {object} models.Output[models.BranchFinance]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 404 {object} models.ErrorOutput
+// @Router /api/v1/admin/finance/id/{id} [get]
 func (f *FinanceController) GetFinanceByID(c *fiber.Ctx) error {
 	financeID := c.Params("id")
 	log.Debug().Str("id", financeID).Msg("Fetching finance by ID")

--- a/pkg/controllers/journals/journals.go
+++ b/pkg/controllers/journals/journals.go
@@ -67,12 +67,11 @@ func New(db *mongo.Database) *JournalHandlers {
 // @Summary Get a journal entry by ID
 // @Description Get a journal entry by its ID
 // @Tags journals
-// @Accept json
 // @Produce json
 // @Param journal_id path string true "Journal ID"
-// @Success 200 {object} models.Journal
-// @Failure 500 {object} models.Error
-// @Router /api/journals/{journal_id} [get]
+// @Success 200 {object} models.Output[models.Journal]
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/journals/{journal_id} [get]
 func (j *JournalHandlers) GetJournalEntryByID(c *fiber.Ctx) error {
 	// log.Info().Msg("Fetching journal entry by ID")
 	journal, err := j.FetchJournalByID(j.ctx, c, true)
@@ -93,14 +92,14 @@ func (j *JournalHandlers) GetJournalEntryByID(c *fiber.Ctx) error {
 // @Summary Query journal entries
 // @Description Query journal entries by branch ID
 // @Tags journals
-// @Accept json
 // @Produce json
 // @Param branch_id path string true "Branch ID"
 // @Param page query int false "Page number"
 // @Param page_size query int false "Page size"
-// @Success 200 {array} models.Journal
-// @Failure 500 {object} models.Error
-// @Router /api/journals/branch/{branch_id} [get]
+// @Success 200 {object} models.Output[[]models.Journal]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/journals/branch/{branch_id} [get]
 func (j *JournalHandlers) QueryJournalEntries(c *fiber.Ctx) error {
 	ctx, span := j.Tracer.Start(j.ctx, "query_journal_entries")
 	defer span.End()
@@ -203,10 +202,10 @@ func QueryJournals(span trace.Span, ctx context.Context, c *fiber.Ctx, queryPara
 // @Accept json
 // @Produce json
 // @Param input body models.NewJournalEntryInput true "New Journal Entry Input"
-// @Success 201 {object} models.Journal
-// @Failure 400 {object} models.Error
-// @Failure 500 {object} models.Error
-// @Router /api/journals [post]
+// @Success 201 {object} models.Output[models.JournalWithTransactionID]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/journals [post]
 func (j *JournalHandlers) NewJournalEntry(c *fiber.Ctx) error {
 	log.Info().Msg("Creating new journal entry")
 	input := models.NewJournalEntryInput{}
@@ -279,10 +278,10 @@ func (j *JournalHandlers) NewJournalEntry(c *fiber.Ctx) error {
 // @Produce json
 // @Param journal_id path string true "Journal ID"
 // @Param input body models.CloseJournalEntryInput true "Close Journal Entry Input"
-// @Success 201 {array} models.Transaction
-// @Failure 400 {object} models.Error
-// @Failure 500 {object} models.Error
-// @Router /api/journals/{journal_id}/close [post]
+// @Success 200 {object} models.Output[models.Journal]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/journals/{journal_id}/close [post]
 func (j *JournalHandlers) CloseJournalEntry(c *fiber.Ctx) error {
 	log.Info().Msg("Closing journal entry")
 	journalID, err := ParseJournalID(c)
@@ -422,12 +421,12 @@ func (j *JournalHandlers) FetchJournalByID(ctx context.Context, c *fiber.Ctx, fe
 // @Summary Reopen a closed journal entry
 // @Description Reopen a journal entry by removing its closing transactions
 // @Tags journals
-// @Accept json
 // @Produce json
 // @Param journal_id path string true "Journal ID"
-// @Success 200 {array} models.Transaction
-// @Failure 500 {object} models.Error
-// @Router /api/journals/{journal_id}/reopen [post]
+// @Success 200 {object} models.Output[models.Journal]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/journals/{journal_id}/reopen [post]
 func (j *JournalHandlers) ReOpenJournalEntry(c *fiber.Ctx) error {
 	log.Info().Msg("Reopening journal entry")
 	// start a db transaction
@@ -541,9 +540,10 @@ func ParseJournalID(c *fiber.Ctx) (bson.ObjectID, error) {
 // @Summary Get a report
 // @Description Get a report of journal entries
 // @Tags journals
-// @Accept json
 // @Produce json
-// @Router /api/journals/report [get]
+// @Success 200 {object} models.MessageResponse
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/journals/report [get]
 func (j *JournalHandlers) GetReport(c *fiber.Ctx) error {
 	log.Info().Msg("Generating report")
 	panic("Not implemented")

--- a/pkg/controllers/journals/operations.go
+++ b/pkg/controllers/journals/operations.go
@@ -52,10 +52,10 @@ func NewOperationsHandler(db *mongo.Database) *OperationHandlers {
 // @Produce json
 // @Param transaction body models.JournalOperationInput true "Transaction data"
 // @Param journal_id path string true "Journal ID"
-// @Success 200 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/journals/{journal_id}/operations [post]
+// @Success 201 {object} models.Output[models.Journal]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/journals/{journal_id}/operations [post]
 func (o *OperationHandlers) NewOperationTransaction(c *fiber.Ctx) error {
 	transaction := models.JournalOperationInput{}
 	if err := c.BodyParser(&transaction); err != nil {
@@ -197,16 +197,16 @@ func (o *OperationHandlers) ShiftIsOpenMiddleware(c *fiber.Ctx) error {
 // @Summary Update an operation transaction
 // @Description Update an operation transaction by ID
 // @Tags journals/operations
-// @Accept json
 // @Produce json
 // @Param id path string true "Operation ID"
 // @Param journal_id path string true "Journal ID"
 // @Param amount query int true "Amount"
 // @Param description query string false "Description"
-// @Success 200 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/journals/{journal_id}/operations/{id} [put]
+// @Success 200 {object} models.Output[models.Journal]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 404 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/journals/{journal_id}/operations/{id} [put]
 func (o *OperationHandlers) UpdateOperationTransactionByID(c *fiber.Ctx) error {
 	// log handler
 	log.Info().Str("operation_id", c.Params("operation_id")).Msg("Updating operation transaction by ID")
@@ -326,14 +326,13 @@ func (o *OperationHandlers) UpdateOperationTransactionByID(c *fiber.Ctx) error {
 // @Summary Delete an operation transaction
 // @Description Delete an operation transaction by ID
 // @Tags journals/operations
-// @Accept json
 // @Produce json
 // @Param id path string true "Operation ID"
 // @Param journal_id path string true "Journal ID"
-// @Success 200 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/journals/{journal_id}/operations/{id} [delete]
+// @Success 200 {object} models.Output[models.Journal]
+// @Failure 404 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/journals/{journal_id}/operations/{id} [delete]
 func (o *OperationHandlers) DeleteOperationTransactionByID(c *fiber.Ctx) error {
 	// log activity
 	log.Info().Str("operation_id", c.Params("operation_id")).Msg("Deleting operation transaction by ID")
@@ -429,14 +428,12 @@ func (o *OperationHandlers) DeleteOperationTransactionByID(c *fiber.Ctx) error {
 // @Summary Get an operation transaction by ID
 // @Description Get an operation transaction by ID
 // @Tags journals/operations
-// @Accept json
 // @Produce json
 // @Param id path string true "Operation ID"
 // @Param journal_id path string true "Journal ID"
-// @Success 200 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/journals/{journal_id}/operations/{id} [get]
+// @Success 200 {object} models.Output[models.Transaction]
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/journals/{journal_id}/operations/{id} [get]
 func (o *OperationHandlers) GetOperationTransactionByID(c *fiber.Ctx) error {
 	// log activity
 

--- a/pkg/controllers/products/product-distribution.go
+++ b/pkg/controllers/products/product-distribution.go
@@ -30,11 +30,11 @@ type NewIncomeInput struct {
 // @Produce json
 // @Param id path string true "Product ID"
 // @Param input body NewIncomeInput true "Income details"
-// @Success 200 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/products/{id}/income [post]
+// @Success 200 {object} models.Output[[]models.Product]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 404 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/products/{id}/income [post]
 func (p *ProductsController) NewIncome(c *fiber.Ctx) error {
 	log.Info().Msg("Starting new income process")
 
@@ -211,9 +211,10 @@ func AppendQuantityDistribution(ctx context.Context, input NewIncomeInput, produ
 // @Summary Transfer product between locations
 // @Description Transfers product quantity from one location to another
 // @Tags products
-// @Accept json
 // @Produce json
-// @Router /api/products/transfer [post]
+// @Success 200 {object} models.Output[[]models.Product]
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/products/transfer [post]
 func (p *ProductsController) NewTransfer(c *fiber.Ctx) error {
 
 	// log activity

--- a/pkg/controllers/products/product-images.go
+++ b/pkg/controllers/products/product-images.go
@@ -19,10 +19,10 @@ import (
 // @Produce json
 // @Param product_id path string true "Product ID"
 // @Param image formData file true "Image file to upload"
-// @Success 200 {object} string
+// @Success 200 {object} map[string]string
 // @Failure 400 {string} string
 // @Failure 500 {string} string
-// @Router /api/products/{product_id}/images [post]
+// @Router /api/v1/admin/products/{product_id}/images [post]
 func (p *ProductsController) UploadProductImage(c *fiber.Ctx) error {
 	file, err := c.FormFile("image")
 	if err != nil {
@@ -82,7 +82,7 @@ func (p *ProductsController) UploadProductImage(c *fiber.Ctx) error {
 // @Success 200 {string} string
 // @Failure 400 {string} string
 // @Failure 500 {string} string
-// @Router /api/products/{product_id}/images/{key} [delete]
+// @Router /api/v1/admin/products/{product_id}/images/{key} [delete]
 func (p *ProductsController) DeleteProductImage(c *fiber.Ctx) error {
 	key := c.Params("key")
 	if key == "" {
@@ -123,10 +123,10 @@ func (p *ProductsController) DeleteProductImage(c *fiber.Ctx) error {
 // @Tags products
 // @Produce json
 // @Param product_id path string true "Product ID"
-// @Success 200 {object} string
+// @Success 200 {object} map[string][]string
 // @Failure 400 {string} string
 // @Failure 500 {string} string
-// @Router /api/products/{product_id}/images [get]
+// @Router /api/v1/admin/products/{product_id}/images [get]
 func (p *ProductsController) GetImagesOfProduct(c *fiber.Ctx) error {
 	productID := c.Params("product_id")
 	if productID == "" {
@@ -157,7 +157,7 @@ func (p *ProductsController) GetImagesOfProduct(c *fiber.Ctx) error {
 // @Success 200 {file} binary
 // @Failure 400 {string} string
 // @Failure 500 {string} string
-// @Router /api/products/images/{key} [get]
+// @Router /api/v1/admin/products/images/{key} [get]
 func (p *ProductsController) GetImage(c *fiber.Ctx) error {
 	key := c.Params("key")
 	if key == "" {

--- a/pkg/controllers/products/products.go
+++ b/pkg/controllers/products/products.go
@@ -43,10 +43,10 @@ func New(db *mongo.Database) *ProductsController {
 // @Accept json
 // @Produce json
 // @Param product body models.ProductBase true "Product details"
-// @Success 201 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/products [post]
+// @Success 201 {object} models.Output[[]models.Product]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/products [post]
 func (p *ProductsController) CreateProduct(c *fiber.Ctx) error {
 	_, span := otel.Tracer("products").Start(c.Context(), "create_product")
 	defer span.End()
@@ -93,10 +93,10 @@ func (p *ProductsController) CreateProduct(c *fiber.Ctx) error {
 // @Produce json
 // @Param id path string true "Product ID"
 // @Param product body models.ProductBase true "Product details to update"
-// @Success 200 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/products/{id} [put]
+// @Success 200 {object} models.Output[[]models.Product]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/products/{id} [put]
 func (p *ProductsController) EditProduct(c *fiber.Ctx) error {
 	_, span := otel.Tracer("products").Start(c.Context(), "edit_product")
 	defer span.End()
@@ -189,12 +189,11 @@ func (p *ProductsController) EditProduct(c *fiber.Ctx) error {
 // @Summary Delete a product
 // @Description Deletes a product and its related data
 // @Tags products
-// @Accept json
 // @Produce json
 // @Param id path string true "Product ID"
-// @Success 200 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/products/{id} [delete]
+// @Success 200 {object} models.Output[[]models.Product]
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/products/{id} [delete]
 func (p *ProductsController) DeleteProduct(c *fiber.Ctx) error {
 	_, span := otel.Tracer("products").Start(c.Context(), "delete_product")
 	defer span.End()
@@ -231,12 +230,11 @@ func (p *ProductsController) DeleteProduct(c *fiber.Ctx) error {
 // @Summary Get a product by ID
 // @Description Retrieves a product by its ID
 // @Tags products
-// @Accept json
 // @Produce json
 // @Param id path string true "Product ID"
-// @Success 200 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Router /api/products/{id} [get]
+// @Success 200 {object} models.Output[[]models.Product]
+// @Failure 404 {object} models.ErrorOutput
+// @Router /api/v1/admin/products/{id} [get]
 func (p *ProductsController) GetProductByID(c *fiber.Ctx) error {
 	_, span := otel.Tracer("products").Start(c.Context(), "get_product_by_id")
 	defer span.End()
@@ -265,16 +263,15 @@ func (p *ProductsController) GetProductByID(c *fiber.Ctx) error {
 // @Summary Query products
 // @Description Query products based on various parameters
 // @Tags products
-// @Accept json
 // @Produce json
 // @Param branch_id query string false "Branch ID"
 // @Param sku query string false "SKU"
 // @Param price_min query number false "Minimum price"
 // @Param price_max query number false "Maximum price"
-// @Success 200 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/products [get]
+// @Success 200 {object} models.Output[[]models.Product]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/products [get]
 func (p *ProductsController) QueryProducts(c *fiber.Ctx) error {
 	_, span := otel.Tracer("products").Start(c.Context(), "query_products")
 	defer span.End()

--- a/pkg/controllers/sales/sales_session.go
+++ b/pkg/controllers/sales/sales_session.go
@@ -19,7 +19,7 @@ package sales
 // // @Accept json
 // // @Produce json
 // // @Param branch_id path string true "Branch ID"
-// // @Success 200 {object} models.Output
+// // @Success 200 {object} models.Output[any]
 // // @Router /api/sales/session/branch/{branch_id} [post]
 // func (s *SalesTransactionsController) OpenSalesSession(c *fiber.Ctx) error {
 // 	branch_id := c.Params("branch_id")
@@ -59,9 +59,9 @@ package sales
 // // @Produce json
 // // @Param session_id path string true "Session ID"
 // // @Param product body AddProductItemToSessionInput true "Product details"
-// // @Success 200 {object} models.Output
-// // @Failure 400 {object} models.Output
-// // @Failure 500 {object} models.Output
+// // @Success 200 {object} models.Output[any]
+// // @Failure 400 {object} models.ErrorOutput
+// // @Failure 500 {object} models.ErrorOutput
 // // @Router /api/sales/session/{session_id}/product [post]
 // func (s *SalesTransactionsController) AddProductItemToSession(c *fiber.Ctx) error {
 // 	session_id := c.Params("session_id")
@@ -118,8 +118,8 @@ package sales
 // // @Accept json
 // // @Produce json
 // // @Param session_id path string true "Session ID"
-// // @Success 200 {object} models.Output
-// // @Failure 500 {object} models.Output
+// // @Success 200 {object} models.Output[any]
+// // @Failure 500 {object} models.ErrorOutput
 // // @Router /api/sales/session/{session_id}/close [post]
 // func (s *SalesTransactionsController) CloseSalesSession(c *fiber.Ctx) error {
 // 	session_id := c.Params("session_id")
@@ -178,10 +178,10 @@ package sales
 // // @Accept json
 // // @Produce json
 // // @Param session_id path string true "Session ID"
-// // @Success 200 {object} models.Output
-// // @Failure 400 {object} models.Output
-// // @Failure 404 {object} models.Output
-// // @Failure 500 {object} models.Output
+// // @Success 200 {object} models.Output[any]
+// // @Failure 400 {object} models.ErrorOutput
+// // @Failure 404 {object} models.ErrorOutput
+// // @Failure 500 {object} models.ErrorOutput
 // // @Router /api/sales/session/{session_id} [get]
 // func (s *SalesTransactionsController) GetSalesSession(c *fiber.Ctx) error {
 // 	session_id := c.Params("session_id")
@@ -209,10 +209,10 @@ package sales
 // // @Accept json
 // // @Produce json
 // // @Param branch_id path string true "Branch ID"
-// // @Success 200 {object} models.Output
-// // @Failure 400 {object} models.Output
-// // @Failure 404 {object} models.Output
-// // @Failure 500 {object} models.Output
+// // @Success 200 {object} models.Output[any]
+// // @Failure 400 {object} models.ErrorOutput
+// // @Failure 404 {object} models.ErrorOutput
+// // @Failure 500 {object} models.ErrorOutput
 // // @Router /api/sales/session/branch/{branch_id} [get]
 // func (s *SalesTransactionsController) GetSalesSessionsOfBranch(c *fiber.Ctx) error {
 // 	branch_id := c.Params("branch_id")
@@ -240,10 +240,10 @@ package sales
 // // @Accept json
 // // @Produce json
 // // @Param session_id path string true "Session ID"
-// // @Success 200 {object} models.Output
-// // @Failure 400 {object} models.Output
-// // @Failure 404 {object} models.Output
-// // @Failure 500 {object} models.Output
+// // @Success 200 {object} models.Output[any]
+// // @Failure 400 {object} models.ErrorOutput
+// // @Failure 404 {object} models.ErrorOutput
+// // @Failure 500 {object} models.ErrorOutput
 // // @Router /api/sales/session/{session_id} [delete]
 // func (s *SalesTransactionsController) DeleteSalesSession(c *fiber.Ctx) error {
 // 	session_id := c.Params("session_id")

--- a/pkg/controllers/sales/sales_transactions.go
+++ b/pkg/controllers/sales/sales_transactions.go
@@ -40,9 +40,9 @@ func New(db *mongo.Database) *SalesTransactionsController {
 // @Produce json
 // @Param branch_id path string true "Branch ID"
 // @Param transaction body models.TransactionBase true "Transaction details"
-// @Success 201 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 500 {object} models.Output
+// @Success 201 {object} models.Output[models.Transaction]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
 // @Router /api/sales/transactions/{branch_id} [post]
 func (s *SalesTransactionsController) CreateSalesTransaction(c *fiber.Ctx) error {
 	branch_id := c.Params("branch_id")
@@ -148,8 +148,8 @@ func NewTransaction(ctx context.Context, transaction_base models.TransactionBase
 // @Accept json
 // @Produce json
 // @Param transaction_id path string true "Transaction ID"
-// @Success 200 {object} models.Output
-// @Failure 500 {object} models.Output
+// @Success 200 {object} models.Output[models.Transaction]
+// @Failure 500 {object} models.ErrorOutput
 // @Router /api/sales/transactions/{transaction_id} [delete]
 func (s *SalesTransactionsController) DeleteSalesTransaction(c *fiber.Ctx) error {
 	transaction_id := c.Params("transaction_id")

--- a/pkg/controllers/store/account/account.go
+++ b/pkg/controllers/store/account/account.go
@@ -1,0 +1,68 @@
+package storeaccount
+
+import (
+	models "github.com/aslon1213/g4h_pos_erp/pkg/repository"
+	"github.com/gofiber/fiber/v2"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// Controller handles the storefront customer account surface (address book, etc).
+type Controller struct {
+	StoreCustomersCollection *mongo.Collection
+	DB                       *mongo.Database
+}
+
+func New(db *mongo.Database) *Controller {
+	return &Controller{
+		StoreCustomersCollection: db.Collection("store_customers"),
+		DB:                       db,
+	}
+}
+
+// GetAddresses godoc
+// @Summary List the customer's saved addresses
+// @Tags store-account
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/account/addresses [get]
+func (ctrl *Controller) GetAddresses(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// CreateAddress godoc
+// @Summary Add a new address to the customer's address book
+// @Tags store-account
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/account/addresses [post]
+func (ctrl *Controller) CreateAddress(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// UpdateAddress godoc
+// @Summary Update an address
+// @Tags store-account
+// @Security BearerAuth
+// @Param address_id path string true "Address ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/account/addresses/{address_id} [put]
+func (ctrl *Controller) UpdateAddress(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// DeleteAddress godoc
+// @Summary Delete an address
+// @Tags store-account
+// @Security BearerAuth
+// @Param address_id path string true "Address ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/account/addresses/{address_id} [delete]
+func (ctrl *Controller) DeleteAddress(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// SetDefaultAddress godoc
+// @Summary Mark an address as the default
+// @Tags store-account
+// @Security BearerAuth
+// @Param address_id path string true "Address ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/account/addresses/{address_id}/default [put]
+func (ctrl *Controller) SetDefaultAddress(c *fiber.Ctx) error { return models.NotImplemented(c) }

--- a/pkg/controllers/store/auth/auth.go
+++ b/pkg/controllers/store/auth/auth.go
@@ -1,0 +1,94 @@
+package storeauth
+
+import (
+	models "github.com/aslon1213/g4h_pos_erp/pkg/repository"
+	"github.com/gofiber/fiber/v2"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// Controller handles storefront customer authentication against the
+// store_customers collection (separate from staff auth).
+type Controller struct {
+	StoreCustomersCollection *mongo.Collection
+	ActivitiesCollection     *mongo.Collection
+	DB                       *mongo.Database
+}
+
+func New(db *mongo.Database) *Controller {
+	return &Controller{
+		StoreCustomersCollection: db.Collection("store_customers"),
+		ActivitiesCollection:     db.Collection("activities"),
+		DB:                       db,
+	}
+}
+
+// Register godoc
+// @Summary Register a storefront customer
+// @Description Create a new storefront customer account
+// @Tags store-auth
+// @Accept json
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/auth/register [post]
+func (ctrl *Controller) Register(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// Login godoc
+// @Summary Login a storefront customer
+// @Description Authenticate a storefront customer and return a token
+// @Tags store-auth
+// @Accept json
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/auth/login [post]
+func (ctrl *Controller) Login(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// RefreshToken godoc
+// @Summary Refresh a storefront access token
+// @Tags store-auth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/auth/refresh [post]
+func (ctrl *Controller) RefreshToken(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// ForgotPassword godoc
+// @Summary Request a password reset
+// @Tags store-auth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/auth/password/forgot [post]
+func (ctrl *Controller) ForgotPassword(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// ResetPassword godoc
+// @Summary Reset a password with a reset token
+// @Tags store-auth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/auth/password/reset [post]
+func (ctrl *Controller) ResetPassword(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// Me godoc
+// @Summary Get current storefront customer profile
+// @Tags store-auth
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/auth/me [get]
+func (ctrl *Controller) Me(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// UpdateMe godoc
+// @Summary Update current storefront customer profile
+// @Tags store-auth
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/auth/me [put]
+func (ctrl *Controller) UpdateMe(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// Logout godoc
+// @Summary Logout the current storefront customer
+// @Tags store-auth
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/auth/logout [post]
+func (ctrl *Controller) Logout(c *fiber.Ctx) error { return models.NotImplemented(c) }

--- a/pkg/controllers/store/cart/cart.go
+++ b/pkg/controllers/store/cart/cart.go
@@ -1,0 +1,87 @@
+package storecart
+
+import (
+	models "github.com/aslon1213/g4h_pos_erp/pkg/repository"
+	"github.com/gofiber/fiber/v2"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// Controller handles the authenticated customer's shopping cart.
+type Controller struct {
+	CartsCollection    *mongo.Collection
+	ProductsCollection *mongo.Collection
+	DB                 *mongo.Database
+}
+
+func New(db *mongo.Database) *Controller {
+	return &Controller{
+		CartsCollection:    db.Collection("carts"),
+		ProductsCollection: db.Collection("products"),
+		DB:                 db,
+	}
+}
+
+// GetCart godoc
+// @Summary Get the current customer's cart
+// @Tags store-cart
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/cart [get]
+func (ctrl *Controller) GetCart(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// AddItem godoc
+// @Summary Add an item to the cart
+// @Tags store-cart
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/cart/items [post]
+func (ctrl *Controller) AddItem(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// UpdateItem godoc
+// @Summary Update a cart item's quantity
+// @Tags store-cart
+// @Security BearerAuth
+// @Param item_id path string true "Cart item ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/cart/items/{item_id} [put]
+func (ctrl *Controller) UpdateItem(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// RemoveItem godoc
+// @Summary Remove an item from the cart
+// @Tags store-cart
+// @Security BearerAuth
+// @Param item_id path string true "Cart item ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/cart/items/{item_id} [delete]
+func (ctrl *Controller) RemoveItem(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// ClearCart godoc
+// @Summary Empty the cart
+// @Tags store-cart
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/cart [delete]
+func (ctrl *Controller) ClearCart(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// ApplyPromo godoc
+// @Summary Apply a coupon code to the cart
+// @Tags store-cart
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/cart/promo [post]
+func (ctrl *Controller) ApplyPromo(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// RemovePromo godoc
+// @Summary Remove the applied coupon from the cart
+// @Tags store-cart
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/cart/promo [delete]
+func (ctrl *Controller) RemovePromo(c *fiber.Ctx) error { return models.NotImplemented(c) }

--- a/pkg/controllers/store/catalog/catalog.go
+++ b/pkg/controllers/store/catalog/catalog.go
@@ -1,0 +1,66 @@
+package storecatalog
+
+import (
+	models "github.com/aslon1213/g4h_pos_erp/pkg/repository"
+	"github.com/gofiber/fiber/v2"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// Controller handles the public catalog browse surface (categories, brands, search).
+type Controller struct {
+	CategoriesCollection *mongo.Collection
+	ProductsCollection   *mongo.Collection
+	DB                   *mongo.Database
+}
+
+func New(db *mongo.Database) *Controller {
+	return &Controller{
+		CategoriesCollection: db.Collection("categories"),
+		ProductsCollection:   db.Collection("products"),
+		DB:                   db,
+	}
+}
+
+// GetCategories godoc
+// @Summary List catalog categories
+// @Tags store-catalog
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/catalog/categories [get]
+func (ctrl *Controller) GetCategories(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetCategoryByID godoc
+// @Summary Get a category by id
+// @Tags store-catalog
+// @Param id path string true "Category ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/catalog/categories/{id} [get]
+func (ctrl *Controller) GetCategoryByID(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetCategoryProducts godoc
+// @Summary List products in a category
+// @Tags store-catalog
+// @Param id path string true "Category ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/catalog/categories/{id}/products [get]
+func (ctrl *Controller) GetCategoryProducts(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetBrands godoc
+// @Summary List brands / manufacturers
+// @Tags store-catalog
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/catalog/brands [get]
+func (ctrl *Controller) GetBrands(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// Search godoc
+// @Summary Search the catalog
+// @Description Full-text search with filters, facets, sort and pagination
+// @Tags store-catalog
+// @Param q query string false "Search query"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/catalog/search [get]
+func (ctrl *Controller) Search(c *fiber.Ctx) error { return models.NotImplemented(c) }

--- a/pkg/controllers/store/orders/orders.go
+++ b/pkg/controllers/store/orders/orders.go
@@ -1,0 +1,89 @@
+package storeorders
+
+import (
+	models "github.com/aslon1213/g4h_pos_erp/pkg/repository"
+	"github.com/gofiber/fiber/v2"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// Controller handles checkout and the customer's orders.
+type Controller struct {
+	OrdersCollection *mongo.Collection
+	CartsCollection  *mongo.Collection
+	DB               *mongo.Database
+}
+
+func New(db *mongo.Database) *Controller {
+	return &Controller{
+		OrdersCollection: db.Collection("orders"),
+		CartsCollection:  db.Collection("carts"),
+		DB:               db,
+	}
+}
+
+// CheckoutPreview godoc
+// @Summary Preview checkout totals (items, shipping, tax) before placing an order
+// @Tags store-orders
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/checkout/preview [post]
+func (ctrl *Controller) CheckoutPreview(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// PlaceOrder godoc
+// @Summary Place an order from the current cart
+// @Tags store-orders
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/orders [post]
+func (ctrl *Controller) PlaceOrder(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// ListOrders godoc
+// @Summary List the customer's orders
+// @Tags store-orders
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/orders [get]
+func (ctrl *Controller) ListOrders(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetOrderByID godoc
+// @Summary Get an order by id
+// @Tags store-orders
+// @Security BearerAuth
+// @Param id path string true "Order ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/orders/{id} [get]
+func (ctrl *Controller) GetOrderByID(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetOrderStatus godoc
+// @Summary Get an order's status / tracking
+// @Tags store-orders
+// @Security BearerAuth
+// @Param id path string true "Order ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/orders/{id}/status [get]
+func (ctrl *Controller) GetOrderStatus(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// CancelOrder godoc
+// @Summary Cancel an order
+// @Tags store-orders
+// @Security BearerAuth
+// @Param id path string true "Order ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/orders/{id}/cancel [post]
+func (ctrl *Controller) CancelOrder(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// ReorderOrder godoc
+// @Summary Re-add the items of a past order to the cart
+// @Tags store-orders
+// @Security BearerAuth
+// @Param id path string true "Order ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/orders/{id}/reorder [post]
+func (ctrl *Controller) ReorderOrder(c *fiber.Ctx) error { return models.NotImplemented(c) }

--- a/pkg/controllers/store/products/products.go
+++ b/pkg/controllers/store/products/products.go
@@ -1,0 +1,79 @@
+package storeproducts
+
+import (
+	models "github.com/aslon1213/g4h_pos_erp/pkg/repository"
+	"github.com/gofiber/fiber/v2"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// Controller handles the public storefront product browse surface (read-only
+// views over the products collection).
+type Controller struct {
+	ProductsCollection *mongo.Collection
+	ReviewsCollection  *mongo.Collection
+	DB                 *mongo.Database
+}
+
+func New(db *mongo.Database) *Controller {
+	return &Controller{
+		ProductsCollection: db.Collection("products"),
+		ReviewsCollection:  db.Collection("reviews"),
+		DB:                 db,
+	}
+}
+
+// ListProducts godoc
+// @Summary List storefront products
+// @Description List products with filter/sort/pagination
+// @Tags store-products
+// @Param page query int false "Page number"
+// @Param count query int false "Items per page"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/products [get]
+func (ctrl *Controller) ListProducts(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetProductByID godoc
+// @Summary Get a storefront product by id
+// @Tags store-products
+// @Param id path string true "Product ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/products/{id} [get]
+func (ctrl *Controller) GetProductByID(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetProductImages godoc
+// @Summary Get a product's images
+// @Tags store-products
+// @Param id path string true "Product ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/products/{id}/images [get]
+func (ctrl *Controller) GetProductImages(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetRelatedProducts godoc
+// @Summary Get related / recommended products
+// @Tags store-products
+// @Param id path string true "Product ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/products/{id}/related [get]
+func (ctrl *Controller) GetRelatedProducts(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetProductAvailability godoc
+// @Summary Get a product's stock availability per branch
+// @Tags store-products
+// @Param id path string true "Product ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/products/{id}/availability [get]
+func (ctrl *Controller) GetProductAvailability(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetProductReviews godoc
+// @Summary List reviews for a product (public)
+// @Tags store-products
+// @Param id path string true "Product ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/products/{id}/reviews [get]
+func (ctrl *Controller) GetProductReviews(c *fiber.Ctx) error { return models.NotImplemented(c) }

--- a/pkg/controllers/store/promotions/promotions.go
+++ b/pkg/controllers/store/promotions/promotions.go
@@ -1,0 +1,57 @@
+package storepromotions
+
+import (
+	models "github.com/aslon1213/g4h_pos_erp/pkg/repository"
+	"github.com/gofiber/fiber/v2"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// Controller handles storefront promotions and coupons.
+type Controller struct {
+	PromotionsCollection *mongo.Collection
+	CartsCollection      *mongo.Collection
+	DB                   *mongo.Database
+}
+
+func New(db *mongo.Database) *Controller {
+	return &Controller{
+		PromotionsCollection: db.Collection("promotions"),
+		CartsCollection:      db.Collection("carts"),
+		DB:                   db,
+	}
+}
+
+// ListPromotions godoc
+// @Summary List active promotions / banners
+// @Tags store-promotions
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/promotions [get]
+func (ctrl *Controller) ListPromotions(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetPromotionByID godoc
+// @Summary Get a promotion by id
+// @Tags store-promotions
+// @Param id path string true "Promotion ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/promotions/{id} [get]
+func (ctrl *Controller) GetPromotionByID(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// GetCoupon godoc
+// @Summary Look up a coupon's terms by code
+// @Tags store-promotions
+// @Param code path string true "Coupon code"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/promotions/coupons/{code} [get]
+func (ctrl *Controller) GetCoupon(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// ValidateCoupon godoc
+// @Summary Validate a coupon against the current cart / customer
+// @Tags store-promotions
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/promotions/validate [post]
+func (ctrl *Controller) ValidateCoupon(c *fiber.Ctx) error { return models.NotImplemented(c) }

--- a/pkg/controllers/store/reviews/reviews.go
+++ b/pkg/controllers/store/reviews/reviews.go
@@ -1,0 +1,65 @@
+package storereviews
+
+import (
+	models "github.com/aslon1213/g4h_pos_erp/pkg/repository"
+	"github.com/gofiber/fiber/v2"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// Controller handles writing and managing product reviews. Public review
+// listing lives on the storefront products controller.
+type Controller struct {
+	ReviewsCollection  *mongo.Collection
+	ProductsCollection *mongo.Collection
+	OrdersCollection   *mongo.Collection
+	DB                 *mongo.Database
+}
+
+func New(db *mongo.Database) *Controller {
+	return &Controller{
+		ReviewsCollection:  db.Collection("reviews"),
+		ProductsCollection: db.Collection("products"),
+		OrdersCollection:   db.Collection("orders"),
+		DB:                 db,
+	}
+}
+
+// CreateReview godoc
+// @Summary Create a review for a product
+// @Tags store-reviews
+// @Security BearerAuth
+// @Param id path string true "Product ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/products/{id}/reviews [post]
+func (ctrl *Controller) CreateReview(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// UpdateReview godoc
+// @Summary Update the caller's own review
+// @Tags store-reviews
+// @Security BearerAuth
+// @Param id path string true "Review ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/reviews/{id} [put]
+func (ctrl *Controller) UpdateReview(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// DeleteReview godoc
+// @Summary Delete the caller's own review
+// @Tags store-reviews
+// @Security BearerAuth
+// @Param id path string true "Review ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/reviews/{id} [delete]
+func (ctrl *Controller) DeleteReview(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// VoteReview godoc
+// @Summary Vote a review helpful / unhelpful
+// @Tags store-reviews
+// @Security BearerAuth
+// @Param id path string true "Review ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/reviews/{id}/vote [post]
+func (ctrl *Controller) VoteReview(c *fiber.Ctx) error { return models.NotImplemented(c) }

--- a/pkg/controllers/store/store.go
+++ b/pkg/controllers/store/store.go
@@ -1,0 +1,42 @@
+package store
+
+import (
+	storeaccount "github.com/aslon1213/g4h_pos_erp/pkg/controllers/store/account"
+	storeauth "github.com/aslon1213/g4h_pos_erp/pkg/controllers/store/auth"
+	storecart "github.com/aslon1213/g4h_pos_erp/pkg/controllers/store/cart"
+	storecatalog "github.com/aslon1213/g4h_pos_erp/pkg/controllers/store/catalog"
+	storeorders "github.com/aslon1213/g4h_pos_erp/pkg/controllers/store/orders"
+	storeproducts "github.com/aslon1213/g4h_pos_erp/pkg/controllers/store/products"
+	storepromotions "github.com/aslon1213/g4h_pos_erp/pkg/controllers/store/promotions"
+	storereviews "github.com/aslon1213/g4h_pos_erp/pkg/controllers/store/reviews"
+	storewishlist "github.com/aslon1213/g4h_pos_erp/pkg/controllers/store/wishlist"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// Controllers aggregates every storefront controller so the wiring (app) and
+// the route tables (routes) can pass a single value instead of nine.
+type Controllers struct {
+	Auth       *storeauth.Controller
+	Account    *storeaccount.Controller
+	Catalog    *storecatalog.Controller
+	Products   *storeproducts.Controller
+	Cart       *storecart.Controller
+	Wishlist   *storewishlist.Controller
+	Orders     *storeorders.Controller
+	Reviews    *storereviews.Controller
+	Promotions *storepromotions.Controller
+}
+
+func New(db *mongo.Database) *Controllers {
+	return &Controllers{
+		Auth:       storeauth.New(db),
+		Account:    storeaccount.New(db),
+		Catalog:    storecatalog.New(db),
+		Products:   storeproducts.New(db),
+		Cart:       storecart.New(db),
+		Wishlist:   storewishlist.New(db),
+		Orders:     storeorders.New(db),
+		Reviews:    storereviews.New(db),
+		Promotions: storepromotions.New(db),
+	}
+}

--- a/pkg/controllers/store/wishlist/wishlist.go
+++ b/pkg/controllers/store/wishlist/wishlist.go
@@ -1,0 +1,60 @@
+package storewishlist
+
+import (
+	models "github.com/aslon1213/g4h_pos_erp/pkg/repository"
+	"github.com/gofiber/fiber/v2"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// Controller handles the customer's wishlist (likelist).
+type Controller struct {
+	WishlistsCollection *mongo.Collection
+	CartsCollection     *mongo.Collection
+	DB                  *mongo.Database
+}
+
+func New(db *mongo.Database) *Controller {
+	return &Controller{
+		WishlistsCollection: db.Collection("wishlists"),
+		CartsCollection:     db.Collection("carts"),
+		DB:                  db,
+	}
+}
+
+// GetWishlist godoc
+// @Summary Get the current customer's wishlist
+// @Tags store-wishlist
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/wishlist [get]
+func (ctrl *Controller) GetWishlist(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// AddItem godoc
+// @Summary Add a product to the wishlist
+// @Tags store-wishlist
+// @Security BearerAuth
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/wishlist/items [post]
+func (ctrl *Controller) AddItem(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// RemoveItem godoc
+// @Summary Remove a product from the wishlist
+// @Tags store-wishlist
+// @Security BearerAuth
+// @Param product_id path string true "Product ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/wishlist/items/{product_id} [delete]
+func (ctrl *Controller) RemoveItem(c *fiber.Ctx) error { return models.NotImplemented(c) }
+
+// MoveItemToCart godoc
+// @Summary Move a wishlist product into the cart
+// @Tags store-wishlist
+// @Security BearerAuth
+// @Param product_id path string true "Product ID"
+// @Produce json
+// @Success 501 {object} models.ErrorOutput
+// @Router /api/v1/store/wishlist/items/{product_id}/move-to-cart [post]
+func (ctrl *Controller) MoveItemToCart(c *fiber.Ctx) error { return models.NotImplemented(c) }

--- a/pkg/controllers/suppliers/suppliers-transactions.go
+++ b/pkg/controllers/suppliers/suppliers-transactions.go
@@ -23,10 +23,10 @@ import (
 // @Param branch_id path string true "Branch ID"
 // @Param supplier_id path string true "Supplier ID"
 // @Param transaction body models.TransactionBase true "Transaction data"
-// @Success 200 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/suppliers/{branch_id}/{supplier_id}/transactions [post]
+// @Success 200 {object} models.Output[models.Transaction]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/suppliers/{branch_id}/{supplier_id}/transactions [post]
 func (s *SuppliersController) NewTransaction(c *fiber.Ctx) error {
 	// if suppliers gets money, that is when we payed money to them,
 	// so we need to add money to the supplier's balance and decrease the debt of the branch also decrease the balance of the branch

--- a/pkg/controllers/suppliers/suppliers.go
+++ b/pkg/controllers/suppliers/suppliers.go
@@ -60,9 +60,9 @@ type SupplierQuery struct {
 // @Param phone query string false "Supplier phone"
 // @Param address query string false "Supplier address"
 // @Param notes query string false "Supplier notes"
-// @Success 200 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/suppliers [get]
+// @Success 200 {object} models.Output[[]models.Supplier]
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/suppliers [get]
 func (s *SuppliersController) GetSuppliers(c *fiber.Ctx) error {
 
 	var query SupplierQuery
@@ -151,10 +151,10 @@ func (s *SuppliersController) GetSuppliers(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Param id path string true "Supplier ID"
-// @Success 200 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/suppliers/{id} [get]
+// @Success 200 {object} models.Output[models.Supplier]
+// @Failure 404 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/suppliers/{id} [get]
 func (s *SuppliersController) GetSupplierByID(c *fiber.Ctx) error {
 	id := c.Params("id")
 	log.Debug().Str("id", id).Msg("Getting supplier by ID")
@@ -188,11 +188,11 @@ func (s *SuppliersController) GetSupplierByID(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Param supplier body models.SupplierBase true "Supplier data"
-// @Success 201 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/suppliers [post]
+// @Success 201 {object} models.Output[models.Supplier]
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 404 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/suppliers [post]
 func (s *SuppliersController) CreateSupplier(c *fiber.Ctx) error {
 	log.Debug().Msg("Creating new supplier")
 
@@ -270,11 +270,11 @@ func (s *SuppliersController) CreateSupplier(c *fiber.Ctx) error {
 // @Produce json
 // @Param id path string true "Supplier ID"
 // @Param supplier body models.SupplierBase true "Supplier data"
-// @Success 200 {object} models.Output
-// @Failure 400 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/suppliers/{id} [put]
+// @Success 200 {object} models.MessageResponse
+// @Failure 400 {object} models.ErrorOutput
+// @Failure 404 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/suppliers/{id} [put]
 func (s *SuppliersController) UpdateSupplier(c *fiber.Ctx) error {
 	id := c.Params("id")
 	log.Debug().Str("id", id).Msg("Updating supplier")
@@ -343,10 +343,10 @@ func (s *SuppliersController) UpdateSupplier(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Param id path string true "Supplier ID"
-// @Success 200 {object} models.Output
-// @Failure 404 {object} models.Output
-// @Failure 500 {object} models.Output
-// @Router /api/suppliers/{id} [delete]
+// @Success 200 {object} models.MessageResponse
+// @Failure 404 {object} models.ErrorOutput
+// @Failure 500 {object} models.ErrorOutput
+// @Router /api/v1/admin/suppliers/{id} [delete]
 func (s *SuppliersController) DeleteSupplier(c *fiber.Ctx) error {
 	id := c.Params("id")
 	log.Debug().Str("id", id).Msg("Deleting supplier")

--- a/pkg/controllers/transactions/transactions.go
+++ b/pkg/controllers/transactions/transactions.go
@@ -47,15 +47,15 @@ func New(db *mongo.Database) *TransactionsController {
 // @Success 200 {object} models.TransactionOutput
 // @Failure 400 {object} models.Error
 // @Failure 500 {object} models.Error
-// @Router /api/transactions/branch/{branch_id} [get]
+// @Router /api/v1/admin/transactions/branch/{branch_id} [get]
 func (s *TransactionsController) GetTransactionsByQueryParams(c *fiber.Ctx) error {
 	s.logger.Info().Msg("GetTransactionsByQueryParams called")
 	branch_id := c.Params("branch_id")
 	if branch_id == "" {
 		s.logger.Warn().Msg("branch_id is required but not provided")
 		return c.Status(401).JSON(
-			models.NewOutput(
-				nil, models.NewError(
+			models.NewErrorOutput(
+				models.NewError(
 					"branch_id is required",
 					fiber.StatusBadRequest,
 				),
@@ -149,7 +149,7 @@ func (s *TransactionsController) GetTransactionsByQueryParams(c *fiber.Ctx) erro
 // @Param transaction_id path string true "Transaction ID"
 // @Success 200 {object} models.TransactionOutputSingle
 // @Failure 500 {object} models.Error
-// @Router /api/transactions/{transaction_id} [get]
+// @Router /api/v1/admin/transactions/{transaction_id} [get]
 func (t *TransactionsController) GetTransactionByID(c *fiber.Ctx) error {
 	t.logger.Info().Msg("GetTransactionByID called")
 	transaction_id := c.Params("id")
@@ -179,7 +179,7 @@ func (t *TransactionsController) GetTransactionByID(c *fiber.Ctx) error {
 // @Param type query string false "Type of transaction"
 // @Success 200 {object} map[string]string "message" : "transaction was succesfully updated"
 // @Failure 500 {object} models.Error
-// @Router /api/transactions/{id} [put]
+// @Router /api/v1/admin/transactions/{id} [put]
 func (t *TransactionsController) UpdateTransactionByID(c *fiber.Ctx) error {
 	t.logger.Info().Msg("UpdateTransactionByID called")
 	idx := c.Params("id")
@@ -227,7 +227,7 @@ func (t *TransactionsController) UpdateTransactionByID(c *fiber.Ctx) error {
 // @Param id path string true "Transaction ID"
 // @Success 200 {object} map[string]string "message" : "transaction was succesfully deleted"
 // @Failure 500 {object} models.Error
-// @Router /api/transactions/{id} [delete]
+// @Router /api/v1/admin/transactions/{id} [delete]
 func (t *TransactionsController) DeleteTransactionByID(c *fiber.Ctx) error {
 	t.logger.Info().Msg("DeleteTransactionByID called")
 	panic("not implemented")
@@ -259,7 +259,7 @@ func (t *TransactionsController) DeleteTransactionByID(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Success 200 {array} models.InitiatorType
-// @Router /api/transactions/docs/initiator_type [get]
+// @Router /api/v1/admin/transactions/docs/initiator_type [get]
 func (t *TransactionsController) GetInitiatorType(c *fiber.Ctx) error {
 	t.logger.Info().Msg("GetInitiatorType called")
 	types := []models.InitiatorType{
@@ -281,7 +281,7 @@ func (t *TransactionsController) GetInitiatorType(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Success 200 {array} models.TransactionType
-// @Router /api/transactions/docs/type [get]
+// @Router /api/v1/admin/transactions/docs/type [get]
 func (t *TransactionsController) GetTransactionType(c *fiber.Ctx) error {
 	t.logger.Info().Msg("GetTransactionType called")
 	types := []models.TransactionType{
@@ -299,7 +299,7 @@ func (t *TransactionsController) GetTransactionType(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Success 200 {array} models.PaymentMethod
-// @Router /api/transactions/docs/payment_method [get]
+// @Router /api/v1/admin/transactions/docs/payment_method [get]
 func (t *TransactionsController) GetPaymentMethod(c *fiber.Ctx) error {
 	t.logger.Info().Msg("GetPaymentMethod called")
 	methods := []models.PaymentMethod{

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -10,14 +10,16 @@ import (
 )
 
 type Middlewares struct {
-	UserCollection       *mongo.Collection
-	ActivitiesCollection *mongo.Collection
+	UserCollection           *mongo.Collection
+	ActivitiesCollection     *mongo.Collection
+	StoreCustomersCollection *mongo.Collection
 }
 
 func New(db *mongo.Database) *Middlewares {
 	return &Middlewares{
-		UserCollection:       db.Collection("users"),
-		ActivitiesCollection: db.Collection("activities"),
+		UserCollection:           db.Collection("users"),
+		ActivitiesCollection:     db.Collection("activities"),
+		StoreCustomersCollection: db.Collection("store_customers"),
 	}
 }
 
@@ -39,6 +41,28 @@ func (m *Middlewares) AuthMiddleware(c *fiber.Ctx) error {
 	}
 	// add the user to the context
 	c.Locals("user", user.Username)
+
+	return c.Next()
+}
+
+// CustomerAuthMiddleware guards the protected storefront routes (/api/v1/store/*).
+// It mirrors AuthMiddleware but validates the PASETO token subject against the
+// store_customers collection (storefront accounts), not the staff users collection.
+func (m *Middlewares) CustomerAuthMiddleware(c *fiber.Ctx) error {
+
+	subject := c.Locals(
+		pasetoware.DefaultContextKey,
+	).(string)
+
+	// retrieve the storefront customer by token subject (customer id)
+	customer := &models.StoreCustomer{}
+	err := m.StoreCustomersCollection.FindOne(c.Context(), bson.M{"_id": subject}).Decode(customer)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to find store customer")
+		return c.SendStatus(fiber.StatusUnauthorized)
+	}
+	// add the customer id to the context for downstream handlers
+	c.Locals("customer", customer.ID)
 
 	return c.Next()
 }

--- a/pkg/repository/output.go
+++ b/pkg/repository/output.go
@@ -12,21 +12,29 @@ type Error struct {
 	Code    int    `json:"code"`
 }
 
-type Output struct {
-	Data  interface{} `json:"data"`
-	Error []Error     `json:"error"`
+// Output is the standard response envelope. T is the type of the Data payload,
+// so callers get a typed body instead of an untyped interface{}.
+type Output[T any] struct {
+	Data  T       `json:"data"`
+	Error []Error `json:"error"`
 }
 
-func NewOutput(data interface{}, errors ...Error) map[string]interface{} {
+// NewOutput builds a success envelope around data of any type T. T is inferred
+// from the argument, so call sites need no type annotation (e.g.
+// NewOutput([]Product{...}) yields Output[[]Product]).
+func NewOutput[T any](data T, errors ...Error) Output[T] {
+	return Output[T]{
+		Data:  data,
+		Error: errors,
+	}
+}
 
-	// if data == nil || reflect.ValueOf(data).IsNil() {
-	// 	data = []interface{}{}
-	// 	log.Info().Msg("Data is nil, setting to empty array")
-	// }
-
-	return map[string]interface{}{
-		"data":  data,
-		"error": errors,
+// NewErrorOutput builds an envelope with no data payload, only errors. Use this
+// instead of NewOutput(nil, ...) — an untyped nil cannot drive type inference.
+func NewErrorOutput(errors ...Error) Output[any] {
+	return Output[any]{
+		Data:  nil,
+		Error: errors,
 	}
 }
 
@@ -49,15 +57,22 @@ func NewErrors(errors ...error) []Error {
 
 func AbortTransactionAndReturnError(ctx context.Context, session *mongo.Session, c *fiber.Ctx, err error) error {
 
-	return c.Status(fiber.StatusInternalServerError).JSON(NewOutput(nil, Error{
+	return c.Status(fiber.StatusInternalServerError).JSON(NewErrorOutput(Error{
 		Message: err.Error(),
 		Code:    fiber.StatusInternalServerError,
 	}))
 }
 
 func ReturnError(c *fiber.Ctx, err error) error {
-	return c.Status(fiber.StatusInternalServerError).JSON(NewOutput(nil, Error{
+	return c.Status(fiber.StatusInternalServerError).JSON(NewErrorOutput(Error{
 		Message: err.Error(),
 		Code:    fiber.StatusInternalServerError,
 	}))
+}
+
+// NotImplemented is a placeholder response for stubbed-out handlers. It returns
+// HTTP 501 in the standard Output envelope so routes are reachable and testable
+// before their business logic is written.
+func NotImplemented(c *fiber.Ctx) error {
+	return c.Status(fiber.StatusNotImplemented).JSON(NewErrorOutput(NewError("not implemented", fiber.StatusNotImplemented)))
 }

--- a/pkg/repository/responses.go
+++ b/pkg/repository/responses.go
@@ -1,0 +1,29 @@
+package models
+
+import "time"
+
+// ErrorOutput is the response envelope returned on error paths: the same shape
+// as Output but with an empty Data and a populated Error list. Used in swaggo
+// `@Failure` annotations so error responses have a concrete, documented schema.
+type ErrorOutput struct {
+	Data  []any   `json:"data"`
+	Error []Error `json:"error"`
+}
+
+// MessageResponse documents handlers that reply with a bare {"message": "..."}
+// object (e.g. delete confirmations) rather than the Output envelope.
+type MessageResponse struct {
+	Message string `json:"message"`
+}
+
+// TokenResponse documents the login response: the PASETO JSON token claims plus
+// the encrypted token in the "data" field (see pasetoware.NewPayload).
+type TokenResponse struct {
+	Audience   string    `json:"aud"`
+	Jti        string    `json:"jti"`
+	Subject    string    `json:"sub"`
+	IssuedAt   time.Time `json:"iat"`
+	Expiration time.Time `json:"exp"`
+	NotBefore  time.Time `json:"nbf"`
+	Data       string    `json:"data"`
+}

--- a/pkg/repository/store_customer_models.go
+++ b/pkg/repository/store_customer_models.go
@@ -1,0 +1,17 @@
+package models
+
+import "time"
+
+// StoreCustomer is a storefront account (separate from the staff-managed POS
+// `customers` collection). Stored in the `store_customers` collection.
+//
+// Phase 1: only the fields required by CustomerAuthMiddleware and the stubbed
+// handlers are defined. The full account model (password hash, verification,
+// addresses, etc.) lands in Phase 2.
+type StoreCustomer struct {
+	ID        string    `json:"id" bson:"_id"`
+	Email     string    `json:"email" bson:"email"`
+	Phone     string    `json:"phone" bson:"phone"`
+	CreatedAt time.Time `json:"created_at" bson:"created_at"`
+	UpdatedAt time.Time `json:"updated_at" bson:"updated_at"`
+}

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -48,17 +48,23 @@ func DashboardRoutes(router *fiber.App, dashboardController *analytics.Dashboard
 	// dashboard.Get("/branches")
 }
 
+// PublicAuthRoutes registers auth endpoints that must stay OUTSIDE the PASETO
+// token guard. It MUST be called before the /api group middleware is registered
+// in SetupRoutes, otherwise these routes would require a token to reach.
+func PublicAuthRoutes(router *fiber.App, authController *auth.AuthControllers, middleware *middleware.Middlewares) {
+	router.Post("/api/v1/admin/auth/login", authController.Login) // login -- public, activity logged here if succesfull
+	// router.Post("/api/v1/admin/auth/register", authController.Register) // register -- disabled
+}
+
 func AuthRoutes(router *fiber.App, authController *auth.AuthControllers, middleware *middleware.Middlewares) {
-	auth := router.Group("/auth")
-	auth.Post("/login", authController.Login)                                // login -- activity logged here if succesfull
-	auth.Post("/register", authController.Register)                          // register -- activity logged here if succesfull
-	router.Get("/api/auth/me", authController.InfoMe)                        // get user info
-	router.Get("/api/activities/recent", authController.GetRecentActivities) // get recent activities
-	router.Get("/api/activities/me", authController.GetActivitesOfUser)      // get activities of user
+	api := router.Group("/api/v1/admin")
+	api.Get("/auth/me", authController.InfoMe)                         // get user info
+	api.Get("/activities/recent", authController.GetRecentActivities) // get recent activities
+	api.Get("/activities/me", authController.GetActivitesOfUser)      // get activities of user
 }
 
 func SuppliersRoutes(router *fiber.App, suppliersController *suppliers.SuppliersController, middleware *middleware.Middlewares) {
-	api := router.Group("/api")
+	api := router.Group("/api/v1/admin")
 	api.Get("/suppliers", suppliersController.GetSuppliers)                                         // get all suppliers
 	api.Get("/suppliers/:id", suppliersController.GetSupplierByID)                                  // get supplier by id
 	api.Post("/suppliers", suppliersController.CreateSupplier)                                      // create supplier -- activity logged here if succesfull                                   // create supplier
@@ -83,7 +89,7 @@ func SalesRoutes(router *fiber.App, salesController *sales.SalesTransactionsCont
 }
 
 func ProductsRoutes(router *fiber.App, productsController *products.ProductsController, middleware *middleware.Middlewares) {
-	api := router.Group("/api")
+	api := router.Group("/api/v1/admin")
 
 	api.Post("/products", productsController.CreateProduct)                        // create product -- activity logged here if succesfull
 	api.Put("/products/:id", productsController.EditProduct)                       // edit product -- activity logged here if succesfull
@@ -99,7 +105,7 @@ func ProductsRoutes(router *fiber.App, productsController *products.ProductsCont
 }
 
 func JournalsRoutes(router *fiber.App, journalsController *journal_handlers.JournalHandlers, operationsController *journal_handlers.OperationHandlers, middleware *middleware.Middlewares) {
-	api := router.Group("/api")
+	api := router.Group("/api/v1/admin")
 	api.Get("/journals/:id", journalsController.GetJournalEntryByID)                                                  // get journal entry by id
 	api.Get("/journals/branch/:branch_id", journalsController.QueryJournalEntries)                                    // query journal entries
 	api.Post("/journals", journalsController.NewJournalEntry)                                                         // create journal entry -- activity logged here if succesfull
@@ -119,7 +125,7 @@ func InternalExpensesRoutes(router *fiber.App, middleware *middleware.Middleware
 }
 
 func FinanceRoutes(router *fiber.App, financeController *finance.FinanceController, middleware *middleware.Middlewares) {
-	api := router.Group("/api")
+	api := router.Group("/api/v1/admin")
 	api.Get("/finance/branches", financeController.GetBranches)                            // get all branches
 	api.Get("/finance/branch/id/:id", financeController.GetFinanceBranchByBranchID)        // get branch by id
 	api.Get("/finance/branch/name/:branch_name", financeController.GetFinanceByBranchName) // get branch by name
@@ -129,7 +135,7 @@ func FinanceRoutes(router *fiber.App, financeController *finance.FinanceControll
 }
 
 func TransactionsRoutes(router *fiber.App, transactionsController *transactions.TransactionsController, middleware *middleware.Middlewares) {
-	api := router.Group("/api")
+	api := router.Group("/api/v1/admin")
 	api.Get("/transactions/branch/:branch_id", transactionsController.GetTransactionsByQueryParams) // get transactions by query params
 	api.Get("/transactions/:id", transactionsController.GetTransactionByID)                         // get transaction by id
 	// router.Post("/transactions/:branch_id", transactionsController.Tra)
@@ -141,7 +147,7 @@ func TransactionsRoutes(router *fiber.App, transactionsController *transactions.
 }
 
 func CustomerRoutes(router *fiber.App, customerController *customers.CustomersController, middleware *middleware.Middlewares) {
-	api := router.Group("/api")
+	api := router.Group("/api/v1/admin")
 	api.Get("/customers", customerController.GetCustomers)          // get all customers
 	api.Get("/customers/:id", customerController.GetCustomerByID)   // get customer by id
 	api.Post("/customers", customerController.CreateCustomer)       // create customer -- activity logged here if succesfull
@@ -150,7 +156,7 @@ func CustomerRoutes(router *fiber.App, customerController *customers.CustomersCo
 }
 
 func BNPLRoutes(router *fiber.App, bnplController *bnpl.BNPLController, middleware *middleware.Middlewares) {
-	api := router.Group("/api")
+	api := router.Group("/api/v1/admin")
 	api.Post("/bnpl", bnplController.NewBNPL)                                   // create bnpl -- activity logged here if succesfull
 	api.Post("/bnpl/:id/credit", bnplController.CreditBNPL)                     // credit bnpl
 	api.Delete("/bnpl/:id", bnplController.DeleteBNPL)                          // delete bnpl
@@ -160,7 +166,7 @@ func BNPLRoutes(router *fiber.App, bnplController *bnpl.BNPLController, middlewa
 }
 
 func ProposalsRoutes(router *fiber.App, proposalsController *arrivals.ProposalsHandlers, middleware *middleware.Middlewares) {
-	api := router.Group("/api")
+	api := router.Group("/api/v1/admin")
 	api.Get("/proposals", proposalsController.GetProposals)               // get proposals
 	api.Get("/proposals/detail", proposalsController.GetProposalDetail)   // get proposal by id
 	api.Post("/proposals/new", proposalsController.NewProposals)          // create proposal

--- a/pkg/routes/store_routes.go
+++ b/pkg/routes/store_routes.go
@@ -1,0 +1,96 @@
+package routes
+
+import (
+	"github.com/aslon1213/g4h_pos_erp/pkg/controllers/store"
+	"github.com/aslon1213/g4h_pos_erp/pkg/middleware"
+	"github.com/gofiber/fiber/v2"
+)
+
+const storePrefix = "/api/v1/store"
+
+// StorePublicRoutes registers the storefront endpoints that require NO token
+// (browse surface + register/login). It MUST be called before the customer
+// token guard is mounted on the /api/v1/store group in SetupRoutes, otherwise
+// these routes would inherit the guard.
+func StorePublicRoutes(router *fiber.App, sc *store.Controllers, mw *middleware.Middlewares) {
+	g := router.Group(storePrefix)
+
+	// customer auth (public)
+	g.Post("/auth/register", sc.Auth.Register)              // register a storefront account
+	g.Post("/auth/login", sc.Auth.Login)                    // login -> token
+	g.Post("/auth/refresh", sc.Auth.RefreshToken)           // refresh access token
+	g.Post("/auth/password/forgot", sc.Auth.ForgotPassword) // request password reset
+	g.Post("/auth/password/reset", sc.Auth.ResetPassword)   // reset password with token
+
+	// catalog (browse)
+	g.Get("/catalog/categories", sc.Catalog.GetCategories)                    // list categories
+	g.Get("/catalog/categories/:id", sc.Catalog.GetCategoryByID)              // category detail
+	g.Get("/catalog/categories/:id/products", sc.Catalog.GetCategoryProducts) // products in category
+	g.Get("/catalog/brands", sc.Catalog.GetBrands)                            // list brands
+	g.Get("/catalog/search", sc.Catalog.Search)                               // search catalog
+
+	// products (browse)
+	g.Get("/products", sc.Products.ListProducts)                            // list products
+	g.Get("/products/:id", sc.Products.GetProductByID)                      // product detail
+	g.Get("/products/:id/images", sc.Products.GetProductImages)             // product images
+	g.Get("/products/:id/related", sc.Products.GetRelatedProducts)          // related products
+	g.Get("/products/:id/availability", sc.Products.GetProductAvailability) // stock per branch
+	g.Get("/products/:id/reviews", sc.Products.GetProductReviews)           // reviews listing (public)
+
+	// promotions (public)
+	g.Get("/promotions", sc.Promotions.ListPromotions)          // active promotions
+	g.Get("/promotions/:id", sc.Promotions.GetPromotionByID)    // promotion detail
+	g.Get("/promotions/coupons/:code", sc.Promotions.GetCoupon) // coupon terms lookup
+}
+
+// StoreProtectedRoutes registers the storefront endpoints that require a valid
+// customer token. It MUST be called after the customer token guard is mounted on
+// the /api/v1/store group in SetupRoutes.
+func StoreProtectedRoutes(router *fiber.App, sc *store.Controllers, mw *middleware.Middlewares) {
+	g := router.Group(storePrefix)
+
+	// customer auth (protected)
+	g.Get("/auth/me", sc.Auth.Me)       // current profile
+	g.Put("/auth/me", sc.Auth.UpdateMe) // update profile
+	g.Post("/auth/logout", sc.Auth.Logout)
+
+	// account / address book
+	g.Get("/account/addresses", sc.Account.GetAddresses)
+	g.Post("/account/addresses", sc.Account.CreateAddress)
+	g.Put("/account/addresses/:address_id", sc.Account.UpdateAddress)
+	g.Delete("/account/addresses/:address_id", sc.Account.DeleteAddress)
+	g.Put("/account/addresses/:address_id/default", sc.Account.SetDefaultAddress)
+
+	// cart
+	g.Get("/cart", sc.Cart.GetCart)
+	g.Post("/cart/items", sc.Cart.AddItem)
+	g.Put("/cart/items/:item_id", sc.Cart.UpdateItem)
+	g.Delete("/cart/items/:item_id", sc.Cart.RemoveItem)
+	g.Delete("/cart", sc.Cart.ClearCart)
+	g.Post("/cart/promo", sc.Cart.ApplyPromo)
+	g.Delete("/cart/promo", sc.Cart.RemovePromo)
+
+	// wishlist (likelist)
+	g.Get("/wishlist", sc.Wishlist.GetWishlist)
+	g.Post("/wishlist/items", sc.Wishlist.AddItem)
+	g.Delete("/wishlist/items/:product_id", sc.Wishlist.RemoveItem)
+	g.Post("/wishlist/items/:product_id/move-to-cart", sc.Wishlist.MoveItemToCart)
+
+	// checkout / orders
+	g.Post("/checkout/preview", sc.Orders.CheckoutPreview)
+	g.Post("/orders", sc.Orders.PlaceOrder)
+	g.Get("/orders", sc.Orders.ListOrders)
+	g.Get("/orders/:id", sc.Orders.GetOrderByID)
+	g.Get("/orders/:id/status", sc.Orders.GetOrderStatus)
+	g.Post("/orders/:id/cancel", sc.Orders.CancelOrder)
+	g.Post("/orders/:id/reorder", sc.Orders.ReorderOrder)
+
+	// reviews (write/manage)
+	g.Post("/products/:id/reviews", sc.Reviews.CreateReview)
+	g.Put("/reviews/:id", sc.Reviews.UpdateReview)
+	g.Delete("/reviews/:id", sc.Reviews.DeleteReview)
+	g.Post("/reviews/:id/vote", sc.Reviews.VoteReview)
+
+	// promotions (protected)
+	g.Post("/promotions/validate", sc.Promotions.ValidateCoupon)
+}


### PR DESCRIPTION
…elope

Restructure the HTTP surface into versioned namespaces and lay the foundation for a customer-facing storefront.

Routing & auth:
- Move all staff endpoints under /api/v1/admin/* (auth, suppliers, products, journals, finance, transactions, customers, bnpl, proposals)
- Keep admin login public (registered before the PASETO guard); disable the register endpoint
- Add storefront API under /api/v1/store/* (auth, account, catalog, products, cart, wishlist, orders, reviews, promotions) as Phase-1 stubs returning HTTP 501
- Add CustomerAuthMiddleware guarding protected store routes against a new store_customers collection; two PASETO guards coexist via Fiber route-registration order

Response envelope:
- Make Output generic (Output[T]); add NewErrorOutput and concrete ErrorOutput / MessageResponse / TokenResponse types
- Type every swaggo @Success/@Failure annotation per endpoint (models.Output[T] / models.ErrorOutput); no bare Output[any]

Docs:
- Add CLAUDE.md and docs/storefront-implementation-guide.md
- Update README.md and regenerate Swagger (docs/)